### PR TITLE
Added YouTube to white list for travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot --allow-dupe chapters/*
+  - awesome_bot --allow-dupe chapters/* --white-list https://www.youtube.com/
 notifications:
   email: false


### PR DESCRIPTION
Seems like Travis CI is having a hard time verifying YouTube links.

Travis CI is used to find broken URLs, I am more then confident that youtube will not disappear as a valid URL link and since most (if not all) YouTube links are to Khronos site I don't foresee them being removed anytime soon.