### PR TITLE
Cleanup Extensions: VK_KHR_depth_stencil_resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Vulkan Guide is designed to help developers get up and going with the world 
 ## When and Why to use Extensions
 > These are supplemental references for the various Vulkan Extensions. Please consult the Vulkan Spec for further details on any extension
 - [Cleanup Extensions](./chapters/extensions/cleanup.md)
-    - `VK_KHR_bind_memory2`, `VK_KHR_create_renderpass2`, `VK_KHR_dedicated_allocation`, `VK_KHR_driver_properties`, `VK_KHR_get_memory_requirements2`, `VK_KHR_get_physical_device_properties2`, `VK_EXT_host_query_reset`, `VK_KHR_maintenance1`, `VK_KHR_maintenance2`, `VK_KHR_maintenance3`, `VK_KHR_separate_depth_stencil_layouts`, `VK_EXT_separate_stencil_usage`, `VK_EXT_sampler_filter_minmax`, `VK_KHR_sampler_mirror_clamp_to_edge`
+    - `VK_KHR_bind_memory2`, `VK_KHR_create_renderpass2`, `VK_KHR_dedicated_allocation`, `VK_KHR_driver_properties`, `VK_KHR_get_memory_requirements2`, `VK_KHR_get_physical_device_properties2`, `VK_EXT_host_query_reset`, `VK_KHR_maintenance1`, `VK_KHR_maintenance2`, `VK_KHR_maintenance3`, `VK_KHR_separate_depth_stencil_layouts`, `VK_KHR_depth_stencil_resolve`, VK_EXT_separate_stencil_usage`, `VK_EXT_sampler_filter_minmax`, `VK_KHR_sampler_mirror_clamp_to_edge`
 - [Device Groups](./chapters/extensions/device_groups.md)
     - `VK_KHR_device_group`, `VK_KHR_device_group_creation`
 - [External Memory and Sychronization](./chapters/extensions/external.md)

--- a/chapters/extensions/cleanup.md
+++ b/chapters/extensions/cleanup.md
@@ -20,6 +20,12 @@ This extension allows an application to call `vkResetQueryPool` from the host in
 
 This extension allows an application when using a depth/stencil format to do an image translation on each the depth and stencil separately. Starting in Vulkan 1.2 this functionality is required for all implementations.
 
+## VK_KHR_depth_stencil_resolve
+
+> Promoted to core in Vulkan 1.2
+
+This extension adds support for automatically resolving multisampled depth/stencil attachments in a subpass in a similar manner as for color attachments.
+
 ## VK_EXT_separate_stencil_usage
 
 > Promoted to core in Vulkan 1.2


### PR DESCRIPTION
Could we add VK_KHR_depth_stencil_resolve for Cleanup Extensions's list ?

[Example for VK_KHR_depth_stencil_resolve](https://github.com/Andreyogld3d/Vulkan_VK_KHR_depth_stencil_resolve)