### PR TITLE
Fix VK_KHR_imageless_framebufferchapter formatting

### DIFF
--- a/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
+++ b/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
@@ -10,7 +10,7 @@
 Promoted to core in Vulkan 1.2
 ====
 
-When creating a `VkFramebuffer` you normally need to pass the `VkImageView`s being used in `VkFramebufferCreateInfo::pAttachments`.
+When creating a `VkFramebuffer` you normally need to pass the `VkImageViews` being used in `VkFramebufferCreateInfo::pAttachments`.
 
 To use an imageless `VkFramebuffer`
 


### PR DESCRIPTION
This PR fixes a very minor formatting error on the VK_KHR_imageless_framebuffer page, where an inline code block was not properly ended.