### PR TITLE
Add task shader entry to decoder ring

### DIFF
--- a/chapters/decoder_ring.adoc
+++ b/chapters/decoder_ring.adoc
@@ -192,6 +192,10 @@ Not everything will be a perfect 1:1 match, the goal is to give a rough idea whe
             | default framebuffer
                         |
                                     | drawable texture
+| task shader
+            | 
+                        | amplification shader
+                                    |                                    
 | tessellation control shader
             | tessellation control shader
                         | hull shader


### PR DESCRIPTION
This PR adds a new entry to the decoder ring for task shaders, which are called amplification shaders in DirectX. No entry was added for mesh shaders, as they are called mesh shaders in DirectX too.