### PR TITLE
Fix a formatting issue caused by a non-escaped apostrophe

### DIFF
--- a/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
+++ b/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
@@ -12,7 +12,7 @@ ifndef::images[:images: ../images/]
 Promoted to core in Vulkan 1.2
 ====
 
-When creating a `VkFramebuffer` you normally need to pass the `VkImageView`s being used in `VkFramebufferCreateInfo::pAttachments`. Needing the `VkImageView` forces an application to make a framebuffer for each swapchain image. With `VK_KHR_imageless_framebuffer` the `VkImageView` information is given at `vkCmdBeginRenderPass` time instead. This means only one `VkFramebuffer` for all the swapchain images. It is important to notice that when the size of the swapchain changes, the `VkFramebuffer` will still need to be recreated to adjust information such as the `height` and `width`.
+When creating a `VkFramebuffer` you normally need to pass the ``VkImageView`s`` being used in `VkFramebufferCreateInfo::pAttachments`. Needing the `VkImageView` forces an application to make a framebuffer for each swapchain image. With `VK_KHR_imageless_framebuffer` the `VkImageView` information is given at `vkCmdBeginRenderPass` time instead. This means only one `VkFramebuffer` for all the swapchain images. It is important to notice that when the size of the swapchain changes, the `VkFramebuffer` will still need to be recreated to adjust information such as the `height` and `width`.
 
 To use an imageless `VkFramebuffer`
 


### PR DESCRIPTION
This PR fixes a minor formatting issue caused by an apostrophe that wasn't properly escaped in inline code. That caused parts of the non-code text to be formatted as code too.