### PR TITLE
Fix code example for VK_KHR_format_feature_flags2

### DIFF
--- a/chapters/formats.adoc
+++ b/chapters/formats.adoc
@@ -58,8 +58,8 @@ if ((formatProperties2.formatProperties.linearTilingFeatures & VK_FORMAT_FEATURE
 ----
 // Using VK_KHR_format_feature_flags2
 VkFormatProperties3KHR formatProperties3;
-formatProperties2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3_KHR;
-formatProperties2.pNext = nullptr;
+formatProperties3.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3_KHR;
+formatProperties3.pNext = nullptr;
 
 VkFormatProperties2 formatProperties2;
 formatProperties2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;

--- a/lang/jp/chapters/formats.adoc
+++ b/lang/jp/chapters/formats.adoc
@@ -57,8 +57,8 @@ if ((formatProperties2.formatProperties.linearTilingFeatures & VK_FORMAT_FEATURE
 ----
 // VK_KHR_format_feature_flags2 を使用
 VkFormatProperties3KHR formatProperties3;
-formatProperties2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3_KHR;
-formatProperties2.pNext = nullptr;
+formatProperties3.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3_KHR;
+formatProperties3.pNext = nullptr;
 
 VkFormatProperties2 formatProperties2;
 formatProperties2.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;


### PR DESCRIPTION
The code sample for using `VK_KHR_format_feature_flags2` had a small typo, and was using the wrong names for the formatProperties3 structure. This PR fixes this.