### PR TITLE
Add chapter for shader language mapping between HLSL and GLSL

### DIFF
--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -49,7 +49,7 @@ Types work similar in GLSL and HLSL. But where GLSL e.g. has explicit vector or 
 
 [NOTE]
 ====
-While GLSL makes heavy use of input and output variables built into the languages called "built-ins", there is no such concept in HLSL. HLSL instead uses link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics[semantics], strings that are attached to inputs or inputs that contain information about the intended use of that variable. In HLSL semantics are also used in the shader interface.
+While GLSL makes heavy use of input and output variables built into the languages called "built-ins", there is no such concept in HLSL. HLSL instead uses link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics[semantics], strings that are attached to inputs or inputs that contain information about the intended use of that variable. They are prefixed with `SV_`.
 ====
 
 === Examples
@@ -92,7 +92,7 @@ GLSL:
 void main() 
 {
     // The vertex index is stored in the gl_VertexIndex built-in
-	outUV = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    outUV = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
 }
 ----
 
@@ -102,7 +102,7 @@ HLSL
 struct VSInput
 {
     // The SV_VertexID semantic declares the VertexIndex member as the vertex index input
-	uint VertexIndex : SV_VertexID
+    uint VertexIndex : SV_VertexID
 };
 
 VSOutput main(VSInput input)
@@ -458,6 +458,7 @@ float4 main(VSOutput input) : SV_TARGET {
 // @todo: change caption or maybe remove completely
 
 === Raytracing
+// @todo: some of the stuff in here is used across different stages (e.g. gl_PrimitiveID)
 [options="header"]
 |====
 | *GLSL*  | *HLSL*
@@ -515,8 +516,11 @@ float4 main(VSOutput input) : SV_TARGET {
 |====
 | *GLSL*  | *HLSL*
 | shared | groupshared
-| gl_GlobalInvocationID | SV_DispatchThreadID semantic
-| gl_LocalInvocationID | SV_GroupThreadID semantic
+| gl_GlobalInvocationID | SV_DispatchThreadID
+| gl_LocalInvocationID | SV_GroupThreadID
+| gl_WorkGroupID | SV_GroupID
+| gl_LocalInvocationIndex | SV_GroupIndex
+| gl_NumWorkGroups | n.a.
 | gl_WorkGroupSize | n.a.
 |====
 
@@ -573,7 +577,21 @@ These shader stages share several functions and built-ins
 | SetMeshOutputsEXT | SetMeshOutputCounts
 | EmitVertex | __StreamType__<__Name__>.Append (e.g. +{TriangleStream<MSOutput>}+)
 | EndPrimitive | __StreamType__<__Name__>.RestartStrip
+// @todo: check these
+| gl_PrimitiveShadingRateEXT | SV_ShadingRate
+| gl_CullPrimitiveEXT | SV_CullPrimitive
 | gl_in | Array argument for main entry (e.g. +{triangle VSInput input[3]}+)
+|====
+
+=== Tessellation shaders
+
+[options="header"]
+|====
+| *GLSL* | *HLSL*
+| gl_InvocationID | SV_OutputControlPointID
+| gl_TessLevelInner | SV_InsideTessFactor
+| gl_TessLevelOuter | SV_TessFactor
+| gl_TessCoord | SV_DomainLocation
 |====
 
 === Misc
@@ -584,9 +602,13 @@ These shader stages share several functions and built-ins
 | gl_PointSize | [[vk::builtin("PointSize")]] | Vulkan only, no direct HLSL equivalent
 | gl_BaseVertexARB | [[vk::builtin("BaseVertex")]] | Vulkan only, no direct HLSL equivalent
 | gl_BaseInstanceARB | [[vk::builtin("PoBaseInstanceintSize")]] | Vulkan only, no direct HLSL equivalent
-| gl_DrawIDARB | [[vk::builtin("DrawIndex")]] | Vulkan only, no direct HLSL equivalent
+| gl_DrawID | [[vk::builtin("DrawIndex")]] | Vulkan only, no direct HLSL equivalent
 | gl_DeviceIndex | [[vk::builtin("DeviceIndex")]] | Vulkan only, no direct HLSL equivalent
-| gl_ViewIndex | SV_ViewID semantic |
+| gl_ViewIndex | SV_ViewID |
+| gl_ClipDistance | SV_ClipDistance |
+| gl_CullDistance | SV_CullDistance |
+| gl_ViewportIndex | SV_ViewportArrayIndex |
+| gl_Layer | SV_RenderTargetArrayIndex |
 | subpassLoad | <SubPassInput>.SubpassLoad |
 | imageLoad | RWTexture1D/2D/3D<T>[] |
 | imageStore | RWTexture1D/2D/3D<T>[] |

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -22,6 +22,10 @@ For more details on using HLSL with Vulkan, visit xref:{chapters}hlsl.adoc[this 
 The following listings are by no means complete, and mappings for newer extensions may be missing. Also note that concepts do not always map 1:1 between GLSL and HLSL. E.g. there are no semantic in GLSL while some newer GLSL functionality may not (yet) be available in HLSL.
 ====
 
+== Extensions
+
+In GLSL extensions need to be explicitly enabled using the `#extension` directive. This is **not** necessary in HLSL. The compiler will automatically select suitable SPIR-V extensions. If required one can use `-fspv-extension` arguments to explicitly select extensions.
+
 == Data types
 
 [NOTE]

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -24,7 +24,7 @@ The following listings are by no means complete, and mappings for newer extensio
 
 == Extensions
 
-In GLSL extensions need to be explicitly enabled using the `#extension` directive. This is **not** necessary in HLSL. The compiler will automatically select suitable SPIR-V extensions. If required one can use `-fspv-extension` arguments to explicitly select extensions.
+In GLSL extensions need to be explicitly enabled using the `#extension` directive. This is **not** necessary in HLSL. The compiler will implicitly select suitable SPIR-V extensions based on the shader. If required one can use `-fspv-extension` arguments to explicitly select extensions.
 
 == Data types
 
@@ -457,7 +457,48 @@ float4 main(VSOutput input) : SV_TARGET {
 == Built-ins and functions mapping
 // @todo: change caption or maybe remove completely
 
+=== Buffer device address
+
+[NOTE]
+====
+Currently, HLSL only supports a link:https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#rawbufferload-and-rawbufferstore[subset] of VK_KHR_buffer_device_address.
+====
+
+==== GLSL
+
+Example:
+[source,glsl]
+----
+layout(push_constant) uniform PushConstants {
+	uint64_t bufferAddress;
+} pushConstants;
+
+layout(buffer_reference, scalar) buffer Data {vec4 f[]; };
+
+void main() {
+    Data data = Data(pushConstants.bufferAddress);
+}
+----
+
+==== HLSL
+
+Example:
+[source,hlsl]
+----
+struct PushConstants {
+	uint64_t bufferAddress;
+};
+[[vk::push_constant]] PushConstants pushConstants;
+
+void main() {
+  float4 data = vk::RawBufferLoad<float4>(pushConstants.bufferAddress);
+}
+----
+
 === Raytracing
+
+==== Built-Ins
+
 // @todo: some of the stuff in here is used across different stages (e.g. gl_PrimitiveID)
 [options="header"]
 |====
@@ -511,6 +552,8 @@ float4 main(VSOutput input) : SV_TARGET {
 |====
 
 === Compute
+
+==== Built-Ins
 
 [options="header"]
 |====

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Sascha Willems
+// Copyright 2023 Sascha Willems
 // SPDX-License-Identifier: CC-BY-4.0
 
 ifndef::chapters[:chapters:]
@@ -468,10 +468,10 @@ float4 main(VSOutput input) : SV_TARGET {
 | reportIntersectionEXT | ReportHit
 | terminateRayEXT | AcceptHitAndEndSearch
 | traceRayEXT | TraceRay
-| rayPayloadEXT (storage qualifier) | Last argument of TraceRay()
+| rayPayloadEXT (storage qualifier) | Last argument of TraceRay
 | rayPayloadInEXT (storage qualifier) | First argument for main entry of any hit, closest hit and miss stage
-| hitAttributeEXT (storage qualifier) | Last argument of ReportHit()
-| callableDataEXT (storage qualifier) | Last argument of CallShader()
+| hitAttributeEXT (storage qualifier) | Last argument of ReportHit
+| callableDataEXT (storage qualifier) | Last argument of CallShader
 | callableDataInEXT (storage qualifier) | First argument for main entry of callabe stage
 | shaderRecordEXT (decorated buffer) | [[vk::shader_record_ext]] annotation for a ConstantBuffer
 | gl_LaunchIDEXT | DispatchRaysIndex
@@ -536,23 +536,23 @@ Example:
 GLSL:
 [source,glsl]
 ----
-groupMemoryBarrier();
-barrier();
+groupMemoryBarrier;
+barrier;
 for (int j = 0; j < 256; j++) {
-    doSomething();
+    doSomething;
 }
-groupMemoryBarrier();
-barrier();
+groupMemoryBarrier;
+barrier;
 ----
 
 HLSL:
 [source,hlsl]
 ----
-GroupMemoryBarrierWithGroupSync();
+GroupMemoryBarrierWithGroupSync;
 for (int j = 0; j < 256; j++) {
-    doSomething();
+    doSomething;
 }
-GroupMemoryBarrierWithGroupSync();
+GroupMemoryBarrierWithGroupSync;
 ----
 
 |====
@@ -609,6 +609,8 @@ These shader stages share several functions and built-ins
 | gl_CullDistance | SV_CullDistance |
 | gl_ViewportIndex | SV_ViewportArrayIndex |
 | gl_Layer | SV_RenderTargetArrayIndex |
+| gl_SampleID | SV_SampleIndex |
+| gl_SamplePosition | EvaluateAttributeAtSample |
 | subpassLoad | <SubPassInput>.SubpassLoad |
 | imageLoad | RWTexture1D/2D/3D<T>[] |
 | imageStore | RWTexture1D/2D/3D<T>[] |
@@ -616,3 +618,62 @@ These shader stages share several functions and built-ins
 | atomicCompSwap | InterlockedCompareExchange |
 | imageAtomicExchange | InterlockedExchange |
 |====
+
+=== Subgroups
+// @todo: not sure, maybe rename or split into others
+[options="header"]
+|====
+| *GLSL* | *HLSL*
+| gl_HelperInvocation | WaveIsHelperLane
+| n.a. | WaveOnce
+| readFirstInvocationARB | WaveReadFirstLane
+| readInvocationARB | WaveReadLaneAt
+| anyInvocationARB | WaveAnyTrue
+| allInvocationsARB | WaveAllTrue
+| allInvocationsEqualARB | WaveAllEqual
+| ballotARB | WaveBallot
+| gl_NumSubgroups | NumSubgroups decorated OpVariable
+| gl_SubgroupID | SubgroupId decorated OpVariable
+| gl_SubGroupSize | WaveGetLaneCount
+| gl_SubgroupInvocationID | WaveGetLaneIndex
+| gl_SubgroupEqMask | n.a.
+| gl_SubgroupGeMask | n.a.
+| gl_SubgroupGtMask | n.a.
+| gl_SubgroupLeMask | n.a.
+| gl_SubgroupLtMask | SubgroupLtMask decorated OpVariablen.a.
+| WaveIsFirstLane | subgroupElect
+| WaveActiveAnyTrue | subgroupAny
+| WaveActiveAllTrue | subgroupAll
+| WaveActiveBallot | subgroupBallot
+| WaveActiveAllEqual | subgroupAllEqual
+| WaveActiveCountBits | subgroupBallotBitCount   
+| WaveActiveBitAdd | subgroupAnd
+| WaveActiveBitOr | subgroupOr
+| WaveActiveBitXor | subgroupXor
+| WaveActiveSum | subgroupAdd
+| WaveActiveProduct | subgroupMul
+| WaveActiveMin | subgroupMin
+| WaveActiveMax | subgroupMax
+| WavePrefixSum | subgroupExclusiveAdd
+| WavePrefixProduct | subgroupExclusiveMul
+| WavePrefixCountBits | subgroupBallotExclusiveBitCount
+| WaveReadLaneAt | subgroupBroadcast
+| WaveReadLaneFirst | subgroupBroadcastFirst
+| QuadReadAcrossX | subgroupQuadSwapHorizontal
+| QuadReadAcrossY | subgroupQuadSwapVertical
+| QuadReadAcrossDiagonal | subgroupQuadSwapDiagonal	 
+| QuadReadLaneAt | subgroupQuadBroadcast
+|====
+
+@todo:
+gl_InstanceIndex
+gl_PatchVerticesIn
+gl_PrimitiveIDIn
+gl_FragCoord
+gl_FrontFacing
+gl_PointCoord
+
+
+gl_FragDepth
+gl_SampleMaskIn
+gl_SampleMask

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -521,7 +521,7 @@ layout (set = 0, binding = 0, rgba8) uniform writeonly image2D outputImage;
 
 [source,hlsl]
 ----
-[[vk::image_format(`image format`)]]
+[[vk::image_format(<image-format>)]]
 RWTexture2D<image-components> <name> : register(<register-type><binding-index>, space<set-index>);
 ----
 

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -133,6 +133,70 @@ VSOutput main(VSInput input)
 Shader interfaces greatly differ between GLSL and HLSL. Vulkan concepts not directly available in HLSL use the link:https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#the-implicit-vk-namespace)[implicit vk namespace].
 ====
 
+=== Descriptor bindings
+
+==== GLSL
+
+[source,glsl]
+----
+layout (set = <set-index>, binding = <binding-index>) uniform <type> <name>
+----
+
+There are two options for defining descriptor set and binding indices in HLSL when using Vulkan.
+
+==== HLSL way
+
+[source,hlsl]
+----
+<type> <name> : register(<register-type><binding-index>, space<set-index>)
+----
+
+Using this syntax, descriptor set and binding indices will be implicitly assigned from the set and binding index.
+
+==== Vulkan namespace
+
+[source,hlsl]
+----
+[[vk::binding(binding-index, set-index)]]
+<type> <name>
+----
+
+With this option, descriptor set and binding indices are explicitly set using `vk::binding`.
+
+[NOTE]
+====
+It's possible to use both the `vk::binding[]` and `register()` syntax for one descriptor. This can be useful if a shader is used for both Vulkan and DirectX.
+====
+
+==== Examples
+
+===== GLSL
+
+[source, glsl]
+----
+layout (set = 1, binding = 0) uniform Node {
+	mat4 matrix;
+} node;
+----
+
+===== HLSL
+----
+struct Node {
+	float4x4 transform;
+};
+
+// HLSL style
+cbuffer NodeBuf : register(b0, space1) { Node node; }
+
+// Vulkan style
+[[vk::binding(0, 1)]]
+cbuffer NodeBuf { Node node; }
+
+// Combined
+[[vk::binding(0, 1)]]
+cbuffer NodeBuf : register(b0, space1) { Node node; }
+----
+
 === Uniforms
 
 ==== GLSL
@@ -161,6 +225,12 @@ layout (set = 0, binding = 1) uniform sampler2D samplerColor;
 ----
 <type> <name> : register(<register-type><binding-index>, space<set-index>)
 ----
+or
+[source,hlsl]
+----
+[[vk::binding(binding-index, set-index)]]
+<type> <name>
+----
 
 Examples:
 [source,hlsl]
@@ -177,7 +247,7 @@ Texture2D textureColor : register(t1);
 SamplerState samplerColor : register(s1);
 ----
 
-`+<register type>+` can be:
+If using the HLSL descriptor binding syntax `+<register type>+` can be:
 
 [options="header"]
 |====

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -454,6 +454,30 @@ float4 main(VSOutput input) : SV_TARGET {
 | sparseTexelsResidentARB | SampleLevel
 |====
 
+=== Image formats
+
+==== GLSL
+
+layout (set = __<set index>__, binding = __image binding index__, __image format__) uniform __optional attribute__ __image type__ __name__;
+
+Example:
+[source,glsl]
+----
+layout (set = 0, binding = 0, rgba8) uniform writeonly image2D outputImage;
+----
+
+==== HLSL
+
+[[vk::image_format(__image format__)]]
+RWTexture2D<__image components__> __name__ : register(__<register type><binding index>__, space__<set index>__);
+
+Example:
+[source,hlsl]
+----
+[[vk::image_format("rgba8")]]
+RWTexture2D<float4> resultImage : register(u0, space0);
+----
+
 == Built-ins and functions mapping
 // @todo: change caption or maybe remove completely
 

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -460,7 +460,7 @@ float4 main(VSOutput input) : SV_TARGET {
 
 [source,glsl,subs=+quotes]
 ----
-layout (set = `<set index>`, binding = `image binding index`, `image format`) uniform `optional attribute` `image type` `name``;
+layout (set = <set index>, binding = <image binding index>, <image format>) uniform <optional attribute> <image type> <name>;
 ----
 
 Example:

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -8,7 +8,7 @@ ifndef::images[:images: images/]
 = Vulkan High Level Shader Language Comparison
 :toc:
 
-While Vulkan itself consumes shaders as xref:{chapters}what_is_spirv.adoc[SPIR-V] shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another
+While Vulkan itself consumes shader in a binary format called xref:{chapters}what_is_spirv.adoc[SPIR-V], shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another
 
 // @todo: maybe also add SPIR-V
 
@@ -512,7 +512,7 @@ These shader stages share several functions and built-ins
 | gl_BaseInstanceARB | [[vk::builtin("PoBaseInstanceintSize")]] | Vulkan only, no direct HLSL equivalent
 | gl_DrawIDARB | [[vk::builtin("DrawIndex")]] | Vulkan only, no direct HLSL equivalent
 | gl_DeviceIndex | [[vk::builtin("DeviceIndex")]] | Vulkan only, no direct HLSL equivalent
-| gl_ViewIndex | SV_ViewID semantic
+| gl_ViewIndex | SV_ViewID semantic |
 | subpassLoad | <SubPassInput>.SubpassLoad |
 | imageLoad | RWTexture1D/2D/3D<T>[] |
 | imageStore | RWTexture1D/2D/3D<T>[] |

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -113,7 +113,6 @@ VSOutput main(VSInput input)
 }
 ----
 
-
 == Shader interface
 
 [NOTE]
@@ -575,6 +574,44 @@ void main() {
 
 === Raytracing
 
+==== Shader stage selection
+
+While GLSL implicitly detects the shader stage (for raytracing) via file extension (or explicitly via compiler arguments), for HLSL raytracing shaders need to be marked by the `[shader("stage")]` semantic:
+
+Example:
+[source,hlsl]
+----
+[shader("closesthit")]
+void main(inout RayPayload rayPayload, in float2 attribs) {
+}
+----
+
+Stage names match GLSL: `raygeneration`, `intersection`, `anyhit`, `closesthit`, `miss`, `callable`
+
+==== Shader record buffer
+
+==== GLSL
+
+Example:
+[source,glsl]
+----
+layout(shaderRecordEXT, std430) buffer SBT {
+  float data;
+};
+----
+
+==== HLSL
+
+Example:
+[source,hlsl]
+----
+struct SBT {
+  float data;
+};
+[[vk::shader_record_ext]]
+ConstantBuffer<SBT> sbt;
+----
+
 ==== Built-Ins
 
 // @todo: some of the stuff in here is used across different stages (e.g. gl_PrimitiveID)
@@ -592,7 +629,6 @@ void main() {
 | hitAttributeEXT (storage qualifier) | Last argument of ReportHit
 | callableDataEXT (storage qualifier) | Last argument of CallShader
 | callableDataInEXT (storage qualifier) | First argument for main entry of callabe stage
-| shaderRecordEXT (decorated buffer) | [[vk::shader_record_ext]] annotation for a ConstantBuffer
 | gl_LaunchIDEXT | DispatchRaysIndex
 | gl_LaunchSizeEXT | DispatchRaysDimensions
 | gl_PrimitiveID | PrimitiveIndex

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -460,7 +460,7 @@ float4 main(VSOutput input) : SV_TARGET {
 
 [source,glsl,subs=+quotes]
 ----
-layout (set = <set index>, binding = <image binding index>, <image format>) uniform <optional attribute> <image type> <name>;
+layout (set = <set-index>, binding = <image-binding-index>, <image-format>) uniform <memory-qualifier> <image-type> <name>;
 ----
 
 Example:

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -860,10 +860,42 @@ These shader stages share several functions and built-ins
 | nonuniformEXT | NonUniformResourceIndex |
 |====
 
-@todo:
-gl_PatchVerticesIn
+== Functions
 
-gl_SampleMaskIn
-gl_SampleMask
+[NOTE]
+====
+Most GLSL functions are also available in HLSL and vice-versa. This chapter lists functions with divergent names. Functions that have a 1:1 counterpart (e.g. `isNan`) aren't listed.
+==== 
 
-@todo: precision types
+[options="header"]
+|====
+| *GLSL* | *HLSL*
+| clamp | saturate
+| dFdx | ddx 
+| dFdxCoarse | ddx_coarse
+| DFdxFine | ddx_fine
+| dFdy | ddy
+| dFdyCoarse | ddy_coarse
+| DFdyFine | ddy_fine
+| fma | mad
+| fract | frac
+| mix | lerp
+|====
+
+* link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-intrinsic-functions[HLSL intrinsic function (Microsoft)]
+* link:https://registry.khronos.org/OpenGL-Refpages/gl4/index.php[OpenGL reference pages]
+
+// @todo:
+// gl_PatchVerticesIn
+
+// gl_SampleMaskIn
+// gl_SampleMask
+
+// precision types
+// buffer types
+
+// SV_GSInstanceID
+// SV_StencilRef
+// SV_Barycentrics
+// SV_Coverage
+// SV_InnerCoverage

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -858,6 +858,8 @@ These shader stages share several functions and built-ins
 | atomicCompSwap | InterlockedCompareExchange |
 | imageAtomicExchange | InterlockedExchange |
 | nonuniformEXT | NonUniformResourceIndex |
+| gl_BaryCoordEXT | SV_Barycentrics |
+| gl_BaryCoordNoPerspEXT | SV_Barycentrics with noperspective | 
 |====
 
 == Functions
@@ -896,6 +898,5 @@ Most GLSL functions are also available in HLSL and vice-versa. This chapter list
 
 // SV_GSInstanceID
 // SV_StencilRef
-// SV_Barycentrics
 // SV_Coverage
 // SV_InnerCoverage

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -5,7 +5,7 @@ ifndef::chapters[:chapters:]
 ifndef::images[:images: images/]
 
 [[shader-decoder-ring]]
-= Vulkan High Level Shader Language Decoder Ring
+= Vulkan High Level Shader Language Comparison
 :toc:
 
 While Vulkan itself consumes shaders as xref:{chapters}what_is_spirv.adoc[SPIR-V] shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -430,35 +430,6 @@ Example:
 [[vk::input_attachment_index(0)]][[vk::binding(0)]] SubpassInput input0;
 ----
 
-=== Compute local size
-
-==== GLSL
-
-[source,glsl]
-----
-layout (local_size_x = `local size x`, local_size_y = `local size y`, local_size_z = `local size z`) in;
-----
-
-Example:
-[source,glsl]
-----
-layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
-----
-
-==== HLSL
-
-[source,hlsl]
-----
-[numthreads(`local size x`, `local size y`, `local size z`)] +
-----
-
-Example:
-[source,hlsl]
-----
-[numthreads(1, 1, 1)]
-void main() {}
-----
-
 === Texture reads
 
 [NOTE]
@@ -667,9 +638,38 @@ ConstantBuffer<SBT> sbt;
 
 === Compute
 
+==== Local workgroup size
+
+===== GLSL
+
+[source,glsl]
+----
+layout (local_size_x = <local-size-x>, local_size_y = <local-size-y>, local_size_z = <local-size-z>) in;
+----
+
+Example:
+[source,glsl]
+----
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+----
+
+===== HLSL
+
+[source,hlsl]
+----
+[numthreads(<local-size-x>, <local-size-y>, <local-size-z>)]
+----
+
+Example:
+[source,hlsl]
+----
+[numthreads(1, 1, 1)]
+void main() {}
+----
+
 ==== Shared memory
 
-==== GLSL
+===== GLSL
 
 Example:
 [source,glsl]
@@ -677,7 +677,7 @@ Example:
 shared vec4 sharedData[1024];
 ----
 
-==== HLSL
+===== HLSL
 
 Example:
 [source,hlsl]
@@ -690,7 +690,6 @@ groupshared float4 sharedData[1024];
 [options="header"]
 |====
 | *GLSL*  | *HLSL*
-| shared | groupshared
 | gl_GlobalInvocationID | SV_DispatchThreadID
 | gl_LocalInvocationID | SV_GroupThreadID
 | gl_WorkGroupID | SV_GroupID

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -125,7 +125,10 @@ Shader interfaces greatly differ between GLSL and HLSL. Vulkan concepts not dire
 
 ==== GLSL
 
-layout (set = __<set index>__, binding = __<binding index>__) uniform __<type>__ __<name>__
+[source,glsl]
+----
+layout (set = <set-index>, binding = <binding-index>) uniform <type> <name>
+----
 
 Examples:
 [source,glsl]
@@ -142,7 +145,10 @@ layout (set = 0, binding = 1) uniform sampler2D samplerColor;
 
 ==== HLSL
 
-__<type>__ __<name>__ : register(__<register type><binding index>__, space__<set index>__)
+[source,hlsl]
+----
+<type> <name> : register(<register-type><binding-index>, space<set-index>)
+----
 
 Examples:
 [source,hlsl]
@@ -175,7 +181,10 @@ SamplerState samplerColor : register(s1);
 
 ==== GLSL
 
-layout (location = __<location index>__) in __<type>__ __<name>__;
+[source,glsl]
+----
+layout (location = <location-index>) in <type> <name>;
+----
 
 Example:
 [source,glsl]
@@ -188,7 +197,10 @@ layout (location = 3) in vec2 inUV1;
 
 ==== HLSL
 
-[[vk::location(__<location index>__)]] __<type>__ __<name>__ : __<semantic type>__;
+[source,hlsl]
+----
+[[vk::location(<location-index>)]] <type> <name> : <semantic-type>;
+----
 
 Example:
 [source,hlsl]
@@ -235,7 +247,10 @@ E.g. for vertex and tessellations shaders.
 
 ===== GLSL
 
-layout (location = __<location index>__) out/in __<type>__ __<name>__;
+[source,glsl]
+----
+layout (location = <location-index>) out/in <type> <name>;
+----
 
 Example:
 [source,glsl]
@@ -253,7 +268,10 @@ void main() {
 
 ===== HLSL
 
-[[vk::location(`<location index>`)]] `<type>` `<name>` : `<semantic type>`;
+[source,hlsl]
+----
+[[vk::location(<location-index>)]] <type> <name> : <semantic-type>;
+----
 
 Example:
 [source,hlsl]
@@ -281,7 +299,10 @@ For fragment shaders.
 
 ===== GLSL
 
-layout (location = __<attachment index>__) out/in __<type>__ __<name>__;
+[source,glsl]
+----
+layout (location = <attachment-index>) out/in <type> <name>;
+----
 
 Example:
 [source,glsl]
@@ -299,7 +320,10 @@ void main() {
 
 ===== HLSL
 
-__<type>__ __<name>__ : SV_TARGET__<attachment index>__;
+[source,hlsl]
+----
+<type> <name> : SV_TARGET<attachment-index>;
+----
 
 Example:
 [source,hlsl]
@@ -323,7 +347,10 @@ FSOutput main(VSOutput input) {
 
 ==== GLSL
 
-layout (push_constant) uniform __structure type__ { __members__ } __name__
+[source,glsl]
+----
+layout (push_constant) uniform <structure-type> { <members> } <name>
+----
 
 Example:
 [source,glsl]
@@ -335,7 +362,10 @@ layout (push_constant) uniform PushConsts {
 
 ==== HLSL
 
-[[vk::push_constant]] __structure type__ pushConsts;
+[source,hlsl]
+----
+[[vk::push_constant]] <structure-type> <name>;
+----
 
 [source,hlsl]
 ----
@@ -349,7 +379,10 @@ struct PushConsts {
 
 ==== GLSL
 
-layout (constant_id = __spec const index__) const int __name__ = __default value__;
+[source,glsl]
+----
+layout (constant_id = <specialization-constant-index>) const int <name> = <default-value>;
+----
 
 Example:
 [source,glsl]
@@ -359,7 +392,10 @@ layout (constant_id = 0) const int SPEC_CONST = 0;
 
 ==== HLSL
 
-[[vk::constant_id(__spec const index__)]] const int __name__ = __default value__;
+[source,hlsl]
+----
+[[vk::constant_id(<specialization-constant-index>)]] const int <name> = <default-value>;
+----
 
 Example:
 [source,hlsl]
@@ -371,7 +407,10 @@ Example:
 
 ==== GLSL
 
-layout (input_attachment_index = __input attachment index__, binding = __binding index__) uniform subpassInput __name__;
+[source,glsl]
+----
+layout (input_attachment_index = <input-attachment-index>, binding = <binding-index>) uniform subpassInput <name>;
+----
 
 Example:
 [source,glsl]
@@ -381,7 +420,10 @@ layout (input_attachment_index = 0, binding = 0) uniform subpassInput input0;
 
 ==== HLSL
 
-[[vk::input_attachment_index(__input attachment index__)]][[vk::binding(__binding index__)]] SubpassInput __name__;
+[source,hlsl]
+----
+[[vk::input_attachment_index(<input-attachment-index>)]][[vk::binding(<binding-index>)]] SubpassInput <name>;
+----
 
 Example:
 [source,hlsl]
@@ -393,7 +435,10 @@ Example:
 
 ==== GLSL
 
+[source,glsl]
+----
 layout (local_size_x = `local size x`, local_size_y = `local size y`, local_size_z = `local size z`) in;
+----
 
 Example:
 [source,glsl]
@@ -403,7 +448,10 @@ layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 ==== HLSL
 
+[source,hlsl]
+----
 [numthreads(`local size x`, `local size y`, `local size z`)] +
+----
 
 Example:
 [source,hlsl]
@@ -458,7 +506,7 @@ float4 main(VSOutput input) : SV_TARGET {
 
 ==== GLSL
 
-[source,glsl,subs=+quotes]
+[source,glsl]
 ----
 layout (set = <set-index>, binding = <image-binding-index>, <image-format>) uniform <memory-qualifier> <image-type> <name>;
 ----
@@ -471,10 +519,10 @@ layout (set = 0, binding = 0, rgba8) uniform writeonly image2D outputImage;
 
 ==== HLSL
 
-[source,hlsl,subs=+quotes]
+[source,hlsl]
 ----
 [[vk::image_format(`image format`)]]
-RWTexture2D<`image components`> `name` : register(`<register type><binding index>`, space`<set index>`);
+RWTexture2D<image-components> <name> : register(<register-type><binding-index>, space<set-index>);
 ----
 
 Example:

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -8,7 +8,7 @@ ifndef::images[:images: images/]
 = Vulkan High Level Shader Language Comparison
 :toc:
 
-While Vulkan itself consumes shader in a binary format called xref:{chapters}what_is_spirv.adoc[SPIR-V], shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another
+While Vulkan itself consumes shaders in a binary format called xref:{chapters}what_is_spirv.adoc[SPIR-V], shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another
 
 // @todo: maybe also add SPIR-V
 
@@ -44,6 +44,19 @@ Types work similar in GLSL and HLSL. But where GLSL e.g. has explicit vector or 
 * link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-data-types[HLSL data types (Microsoft)]
 * link:https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)[GLSL data types (OpenGL wiki)]
 
+The syntax for casting types also differs:
+
+GLSL:
+[source,glsl]
+----
+mat4x3 mat = mat4x3(ubo.view);
+----
+
+HLSL:
+[source,hlsl]
+----
+float4x3 mat = (float4x3)(ubo.view);
+----
 
 == Built-ins vs. Semantics
 

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -44,6 +44,76 @@ Types work similar in GLSL and HLSL. But where GLSL e.g. has explicit vector or 
 * link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-data-types[HLSL data types (Microsoft)]
 * link:https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)[GLSL data types (OpenGL wiki)]
 
+
+== Built-ins vs. Semantics
+
+[NOTE]
+====
+While GLSL makes heavy use of input and output variables built into the languages called "built-ins", there is no such concept in HLSL. HLSL instead uses link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics[semantics], strings that are attached to inputs or inputs that contain information about the intended use of that variable. In HLSL semantics are also used in the shader interface.
+====
+
+=== Examples
+
+Writing positions from the vertex shader:
+
+GLSL:
+[source,glsl]
+----
+layout (location = 0) in vec4 inPos;
+
+void main() {
+    // The vertex output position is written to the gl_Position built-in
+    gl_Position = ubo.projectionMatrix * ubo.viewMatrix * ubo.modelMatrix * inPos.xyz;
+}
+----
+
+HLSL
+[source,hlsl]
+----
+struct VSOutput
+{
+    // The SV_POSITION semantic declares the Pos member as the vertex output position 
+	float4 Pos : SV_POSITION;
+};
+
+VSOutput main(VSInput input)
+{
+	VSOutput output = (VSOutput)0;
+	output.Pos = mul(ubo.projectionMatrix, mul(ubo.viewMatrix, mul(ubo.modelMatrix, input.Pos)));
+	return output;
+}
+----
+
+Reading the vertex index:
+
+GLSL:
+[source,glsl]
+----
+void main() 
+{
+    // The vertex index is stored in the gl_VertexIndex built-in
+	outUV = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+}
+----
+
+HLSL
+[source,hlsl]
+----
+struct VSInput
+{
+    // The SV_VertexID semantic declares the VertexIndex member as the vertex index input
+	uint VertexIndex : SV_VertexID
+};
+
+VSOutput main(VSInput input)
+{
+	VSOutput output = (VSOutput)0;
+	output.UV = float2((input.VertexIndex << 1) & 2, input.VertexIndex & 2);
+	return output;
+}
+----
+
+
 == Shader interface
 
 [NOTE]

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -1,4 +1,4 @@
-// Copyright 2023 Sascha Willems
+// Copyright 2024 Sascha Willems
 // SPDX-License-Identifier: CC-BY-4.0
 
 ifndef::chapters[:chapters:]
@@ -9,8 +9,6 @@ ifndef::images[:images: images/]
 :toc:
 
 While Vulkan itself consumes shaders in a binary format called xref:{chapters}what_is_spirv.adoc[SPIR-V], shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another
-
-// @todo: maybe also add SPIR-V
 
 [TIP]
 ====
@@ -57,6 +55,11 @@ HLSL:
 ----
 float4x3 mat = (float4x3)(ubo.view);
 ----
+
+[NOTE]
+====
+An imporant difference: Matrices in GLSL are column-major, while matrices in HLSL are row-major. This affects things like matrix construction.
+====
 
 == Built-ins vs. Semantics
 
@@ -186,15 +189,15 @@ struct Node {
 };
 
 // HLSL style
-cbuffer NodeBuf : register(b0, space1) { Node node; }
+ConstantBuffer<Node> node : register(b0, space1);
 
 // Vulkan style
 [[vk::binding(0, 1)]]
-cbuffer NodeBuf { Node node; }
+ConstantBuffer<Node> node;
 
 // Combined
 [[vk::binding(0, 1)]]
-cbuffer NodeBuf : register(b0, space1) { Node node; }
+ConstantBuffer<Node> node : register(b0, space1);
 ----
 
 === Uniforms
@@ -240,7 +243,7 @@ struct UBO
 {
     float4x4 projection;
 };
-cbuffer ubo : register(b0, space0) { UBO ubo; };
+ConstantBuffer<UBO> ubo : register(b0, space0);
 
 // Combined image sampler
 Texture2D textureColor : register(t1);
@@ -253,10 +256,10 @@ If using the HLSL descriptor binding syntax `+<register type>+` can be:
 |====
 | *Type* | *Register Description* | *Vulkan resource*
 | b | Constant buffer | Uniform buffer
-| t | Texture and texture buffer | same
-| c | Buffer offset | n.a.
+| t | Texture and texture buffer | Uniform texel buffer and read-only shader storage buffer
+| c | Buffer offset | `layout(offset = N)`
 | s | Sampler | same
-| u | Unordered Access View | Shader storage buffer
+| u | Unordered Access View | Shader storage buffer, storage image and storage texel buffer
 |====
 
 === Shader inputs
@@ -427,6 +430,11 @@ FSOutput main(VSOutput input) {
 
 === Push constants
 
+[NOTE]
+====
+Push constants must be handled through a root signature in D3D.
+====
+
 ==== GLSL
 
 [source,glsl]
@@ -458,6 +466,11 @@ struct PushConsts {
 ----
 
 === Specialization constants
+
+[NOTE]
+====
+Specialization constants are only available in Vulkan, D3D doesn't offer anything similar.
+====
 
 ==== GLSL
 
@@ -550,7 +563,7 @@ float4 main(VSOutput input) : SV_TARGET {
 | textureGrad | SampleGrad
 | textureLod | SampleLevel
 | textureSize | GetDimensions
-| textureProj | n.a.
+| textureProj | n.a., requires manual perspective divide
 | texelFetch | Load
 | sparseTexelsResidentARB | SampleLevel
 |====
@@ -956,17 +969,3 @@ Most GLSL functions are also available in HLSL and vice-versa. This chapter list
 
 * link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-intrinsic-functions[HLSL intrinsic function (Microsoft)]
 * link:https://registry.khronos.org/OpenGL-Refpages/gl4/index.php[OpenGL reference pages]
-
-// @todo:
-// gl_PatchVerticesIn
-
-// gl_SampleMaskIn
-// gl_SampleMask
-
-// precision types
-// buffer types
-
-// SV_GSInstanceID
-// SV_StencilRef
-// SV_Coverage
-// SV_InnerCoverage

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -594,31 +594,6 @@ These shader stages share several functions and built-ins
 | gl_TessCoord | SV_DomainLocation
 |====
 
-=== Misc
-// @todo: rename, split
-[options="header"]
-|====
-| *GLSL*  | *HLSL* | *Note*
-| gl_PointSize | [[vk::builtin("PointSize")]] | Vulkan only, no direct HLSL equivalent
-| gl_BaseVertexARB | [[vk::builtin("BaseVertex")]] | Vulkan only, no direct HLSL equivalent
-| gl_BaseInstanceARB | [[vk::builtin("PoBaseInstanceintSize")]] | Vulkan only, no direct HLSL equivalent
-| gl_DrawID | [[vk::builtin("DrawIndex")]] | Vulkan only, no direct HLSL equivalent
-| gl_DeviceIndex | [[vk::builtin("DeviceIndex")]] | Vulkan only, no direct HLSL equivalent
-| gl_ViewIndex | SV_ViewID |
-| gl_ClipDistance | SV_ClipDistance |
-| gl_CullDistance | SV_CullDistance |
-| gl_ViewportIndex | SV_ViewportArrayIndex |
-| gl_Layer | SV_RenderTargetArrayIndex |
-| gl_SampleID | SV_SampleIndex |
-| gl_SamplePosition | EvaluateAttributeAtSample |
-| subpassLoad | <SubPassInput>.SubpassLoad |
-| imageLoad | RWTexture1D/2D/3D<T>[] |
-| imageStore | RWTexture1D/2D/3D<T>[] |
-| atomicAdd | InterlockedAdd |
-| atomicCompSwap | InterlockedCompareExchange |
-| imageAtomicExchange | InterlockedExchange |
-|====
-
 === Subgroups
 // @todo: not sure, maybe rename or split into others
 [options="header"]
@@ -665,15 +640,43 @@ These shader stages share several functions and built-ins
 | QuadReadLaneAt | subgroupQuadBroadcast
 |====
 
+=== Misc
+// @todo: rename, split
+[options="header"]
+|====
+| *GLSL*  | *HLSL* | *Note*
+| gl_PointSize | [[vk::builtin("PointSize")]] | Vulkan only, no direct HLSL equivalent
+| gl_BaseVertexARB | [[vk::builtin("BaseVertex")]] | Vulkan only, no direct HLSL equivalent
+| gl_BaseInstanceARB | [[vk::builtin("PoBaseInstanceintSize")]] | Vulkan only, no direct HLSL equivalent
+| gl_DrawID | [[vk::builtin("DrawIndex")]] | Vulkan only, no direct HLSL equivalent
+| gl_DeviceIndex | [[vk::builtin("DeviceIndex")]] | Vulkan only, no direct HLSL equivalent
+| gl_FragCoord | SV_Position |
+| gl_FragDepth | SV_Depth |
+| gl_FrontFacing | SV_IsFrontFace |
+| gl_InstanceIndex | SV_InstanceID |
+| gl_ViewIndex | SV_ViewID |
+| gl_ClipDistance | SV_ClipDistance |
+| gl_CullDistance | SV_CullDistance |
+| gl_PointCoord | SV_Position |
+| gl_Position | SV_Position |
+| gl_PrimitiveID | SV_PrimitiveID |
+| gl_ViewportIndex | SV_ViewportArrayIndex |
+| gl_Layer | SV_RenderTargetArrayIndex |
+| gl_SampleID | SV_SampleIndex |
+| gl_SamplePosition | EvaluateAttributeAtSample |
+| subpassLoad | <SubPassInput>.SubpassLoad |
+| imageLoad | RWTexture1D/2D/3D<T>[] |
+| imageStore | RWTexture1D/2D/3D<T>[] |
+| atomicAdd | InterlockedAdd |
+| atomicCompSwap | InterlockedCompareExchange |
+| imageAtomicExchange | InterlockedExchange |
+| nonuniformEXT | NonUniformResourceIndex |
+|====
+
 @todo:
-gl_InstanceIndex
 gl_PatchVerticesIn
-gl_PrimitiveIDIn
-gl_FragCoord
-gl_FrontFacing
-gl_PointCoord
 
-
-gl_FragDepth
 gl_SampleMaskIn
 gl_SampleMask
+
+@todo: precision types

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -253,14 +253,14 @@ void main() {
 
 ===== HLSL
 
-[[vk::location(__<location index>__)]] __<type>__ __<name>__ : __<semantic type>__;
+[[vk::location(`<location index>`)]] `<type>` `<name>` : `<semantic type>`;
 
 Example:
 [source,hlsl]
 ----
 struct VSOutput
 {
-	float4 Pos : SV_POSITION;
+	                float4 Pos : SV_POSITION;
 [[vk::location(0)]] float3 Normal : NORMAL;
 [[vk::location(1)]] float3 Color : COLOR;
 [[vk::location(2)]] float2 UV : TEXCOORD0;
@@ -393,7 +393,7 @@ Example:
 
 ==== GLSL
 
-layout (local_size_x = __local size x__, local_size_y = __local size y__, local_size_z = __local size z__) in;
+layout (local_size_x = `local size x`, local_size_y = `local size y`, local_size_z = `local size z`) in;
 
 Example:
 [source,glsl]
@@ -403,7 +403,7 @@ layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 ==== HLSL
 
-[numthreads(__local size x__, __local size y__, __local size z__)] +
+[numthreads(`local size x`, `local size y`, `local size z`)] +
 
 Example:
 [source,hlsl]

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -49,7 +49,7 @@ Types work similar in GLSL and HLSL. But where GLSL e.g. has explicit vector or 
 
 [NOTE]
 ====
-While GLSL makes heavy use of input and output variables built into the languages called "built-ins", there is no such concept in HLSL. HLSL instead uses link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics[semantics], strings that are attached to inputs or inputs that contain information about the intended use of that variable. They are prefixed with `SV_`.
+While GLSL makes heavy use of input and output variables built into the languages called "built-ins", there is no such concept in HLSL. HLSL instead uses link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics[semantics], strings that are attached to inputs or inputs that contain information about the intended use of that variable. They are prefixed with `SV_`. For HLSL input values are explicit arguments for the main entry point and the shader needs to explicitly return an output.
 ====
 
 === Examples
@@ -666,6 +666,24 @@ ConstantBuffer<SBT> sbt;
 |====
 
 === Compute
+
+==== Shared memory
+
+==== GLSL
+
+Example:
+[source,glsl]
+----
+shared vec4 sharedData[1024];
+----
+
+==== HLSL
+
+Example:
+[source,hlsl]
+----
+groupshared float4 sharedData[1024];
+----
 
 ==== Built-Ins
 

--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -458,7 +458,10 @@ float4 main(VSOutput input) : SV_TARGET {
 
 ==== GLSL
 
-layout (set = __<set index>__, binding = __image binding index__, __image format__) uniform __optional attribute__ __image type__ __name__;
+[source,glsl,subs=+quotes]
+----
+layout (set = `<set index>`, binding = `image binding index`, `image format`) uniform `optional attribute` `image type` `name``;
+----
 
 Example:
 [source,glsl]
@@ -468,8 +471,11 @@ layout (set = 0, binding = 0, rgba8) uniform writeonly image2D outputImage;
 
 ==== HLSL
 
-[[vk::image_format(__image format__)]]
-RWTexture2D<__image components__> __name__ : register(__<register type><binding index>__, space__<set index>__);
+[source,hlsl,subs=+quotes]
+----
+[[vk::image_format(`image format`)]]
+RWTexture2D<`image components`> `name` : register(`<register type><binding index>`, space`<set index>`);
+----
 
 Example:
 [source,hlsl]

--- a/chapters/shader_language_decoder_ring.adoc
+++ b/chapters/shader_language_decoder_ring.adoc
@@ -1,0 +1,258 @@
+// Copyright 2019-2023 Sascha Willems
+// SPDX-License-Identifier: CC-BY-4.0
+
+ifndef::chapters[:chapters:]
+ifndef::images[:images: images/]
+
+[[shader-decoder-ring]]
+= Vulkan High Level Shader Language Decoder Ring
+
+While Vulkan itself consumes shaders as xref:{chapters}what_is_spirv.adoc[SPIR-V] shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another
+
+// @todo: maybe also add SPIR-V
+
+[TIP]
+====
+For more details on using HLSL with Vulkan, visit xref:{chapters}hlsl.adoc[this chapter].
+====
+
+[NOTE]
+====
+The following listings are by no means complete, and mappings for newer extensions may be missing. Also note that concepts do not always map 1:1 between GLSL and HLSL. E.g. there are no semantic in GLSL while some newer GLSL functionality may not (yet) be available in HLSL.
+====
+
+== Data types
+
+[NOTE]
+====
+Types work similar in GLSL and HLSL. But where GLSL e.g. has explicit vector or matrix types, HLSL uses basic types. On the other hand HLSL offers advanced type features like C++ templates. This paragraph contains a basic summary with some examples to show type differences between the two languages.
+====
+
+[options="header"]
+|====
+| *GLSL* | *HLSL* | *Example*
+| vec__n__ | float__n__ | vec4 -> float4
+| ivec__n__ | int__n__ | ivec3 --> int3
+| mat__nxm__ or shorthand mat__n__ | float__nxm__ | mat4 -> float4x4
+|====
+
+* link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-data-types[HLSL data types (Microsoft)]
+* link:https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)[GLSL data types (OpenGL wiki)]
+
+== Shader interface
+
+[NOTE]
+====
+Shader interfaces greatly differ between GLSL and HLSL. Vulkan concepts not directly available in HLSL use the link:https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#the-implicit-vk-namespace)[implicit vk namespace].
+====
+
+=== Uniforms
+
+==== GLSL
+
+layout (set = __<set index>__, binding = __<binding index>__) uniform __<type>__ __<name>__
+
+Examples:
+[source,glsl]
+----
+// Uniform buffer
+layout (set = 0, binding = 0) uniform UBO 
+{
+    mat4 projection;
+} ubo;
+
+// Combined image sampler
+layout (set = 0, binding = 1) uniform sampler2D samplerColor;
+----
+
+==== HLSL
+
+__<type>__ __<name>__ : register(__<register type><binding index>__, space__<set index>__)
+
+Examples:
+[source,hlsl]
+----
+// Uniform buffer
+struct UBO
+{
+    float4x4 projection;
+};
+cbuffer ubo : register(b0, space0) { UBO ubo; };
+
+// Combined image sampler
+Texture2D textureColor : register(t1);
+SamplerState samplerColor : register(s1);
+----
+
+`+<register type>+` can be:
+
+[options="header"]
+|====
+| *Type* | *Register Description* | *Vulkan resource*
+| b | Constant buffer | Uniform buffer
+| t | Texture and texture buffer | same
+| c | Buffer offset | n.a.
+| s | Sampler | same
+| u | Unordered Access View | Shader storage buffer
+|====
+
+=== Shader inputs
+
+==== GLSL
+
+layout (location = __<location index>__) in __<type>__ __<name>__;
+
+Example:
+[source,glsl]
+----
+layout (location = 0) in vec3 inPos;
+layout (location = 1) in vec3 inNormal;
+layout (location = 2) in vec2 inUV0;
+layout (location = 3) in vec2 inUV1;
+----
+
+==== HLSL
+
+[[vk::location(__<location index>__)]] __<type>__ __<name>__ : __<semantic type>__;
+
+Example:
+[source,hlsl]
+----
+struct VSInput
+{
+[[vk::location(0)]] float3 Pos : POSITION;
+[[vk::location(1)]] float3 Normal : NORMAL;
+[[vk::location(2)]] float2 UV0 : TEXCOORD0;
+[[vk::location(3)]] float2 UV1 : TEXCOORD1;
+};
+
+VSOutput main(VSInput input) {
+}
+----
+
+`+<semantic type>+` can be
+[options="header"]
+|====
+| *Semantic* | *Description* | *Type*
+| BINORMAL[n] | Binormal | float4
+| BLENDINDICES[n] | Blend indices | uint
+| BLENDWEIGHT[n] | Blend weights | float
+| COLOR[n] | Diffuse and specular color | float4
+| NORMAL[n] | Normal vector | float4
+| POSITION[n] | Vertex position in object space. | float4
+| POSITIONT	Transformed vertex position | float4
+| PSIZE[n] | Point size | float
+| TANGENT[n] | Tangent | float4
+| TEXCOORD[n] | Texture coordinates | float4
+|====
+
+`+n+` is an optional integer between 0 and the number of resources supported.
+
+link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics[source]
+
+=== Shader outputs
+
+==== GLSL
+
+layout (location = __<location index>__) out __<type>__ __<name>__;
+
+Example:
+[source,glsl]
+----
+layout (location = 0) out vec3 outNormal;
+layout (location = 1) out vec3 outColor;
+layout (location = 2) out vec2 outUV;
+layout (location = 3) out vec3 outViewVec;
+
+void main() {
+    gl_Position = vec4(inPos, 1.0);
+    outNormal = inNormal;
+}
+----
+
+==== HLSL
+
+[[vk::location(__<location index>__)]] __<type>__ __<name>__ : __<semantic type>__;
+
+Example:
+[source,hlsl]
+----
+struct VSOutput
+{
+	float4 Pos : SV_POSITION;
+[[vk::location(0)]] float3 Normal : NORMAL;
+[[vk::location(1)]] float3 Color : COLOR;
+[[vk::location(2)]] float2 UV : TEXCOORD0;
+[[vk::location(3)]] float3 ViewVec : TEXCOORD1;
+}
+
+VSOutput main(VSInput input) {
+    VSOutput output = (VSOutput)0;
+    output.Pos = float4(input.Pos.xyz, 1.0);
+    output.Normal = input.Normal;
+    return output;
+}
+----
+
+== Built-ins and functions mapping
+// @todo: change caption
+
+=== Raytracing
+|====
+| *GLSL*  | *HLSL*
+| accelerationStructureEXT | RaytracingAccelerationStructure
+| executeCallableEXT | CallShader
+| ignoreIntersectionEXT | IgnoreHit
+| reportIntersectionEXT | ReportHit
+| terminateRayEXT | AcceptHitAndEndSearch
+| traceRayEXT | TraceRay
+| rayPayloadEXT (storage qualifier) | Last argument of TraceRay()
+| rayPayloadInEXT (storage qualifier) | First argument for main entry of any hit, closest hit and miss stage
+| hitAttributeEXT (storage qualifier) | Last argument of ReportHit()
+| callableDataEXT (storage qualifier) | Last argument of CallShader()
+| callableDataInEXT (storage qualifier) | First argument for main entry of callabe stage
+| shaderRecordEXT (decorated buffer) | @todo
+| gl_LaunchIDEXT | DispatchRaysIndex
+| gl_LaunchSizeEXT | DispatchRaysDimensions
+| gl_PrimitiveID | PrimitiveIndex
+| gl_InstanceID | InstanceIndex
+| gl_InstanceCustomIndexEXT | InstanceID
+| gl_GeometryIndexEXT | GeometryIndex
+| gl_VertexIndex | SV_VertexID |
+| gl_WorldRayOriginEXT | WorldRayOrigin
+| gl_WorldRayDirectionEXT | WorldRayDirection
+| gl_ObjectRayOriginEXT | ObjectRayOrigin
+| gl_ObjectRayDirectionEXT | ObjectRayDirection	
+| gl_RayTminEXT | RayTMin
+| gl_RayTmaxEXT | RayTCurrent
+| gl_IncomingRayFlagsEXT | RayFlags
+| gl_HitTEXT | RayTCurrent
+| gl_HitKindEXT | HitKind
+| gl_ObjectToWorldEXT | ObjectToWorld4x3
+| gl_WorldToObjectEXT | WorldToObject4x3 
+| gl_WorldToObject3x4EXT | WorldToObject3x4
+| gl_ObjectToWorld3x4EXT | ObjectToWorld3x4
+| gl_RayFlagsNoneEXT | RAY_FLAG_NONE 
+| gl_RayFlagsOpaqueEXT | RAY_FLAG_FORCE_OPAQUE
+| gl_RayFlagsNoOpaqueEXT | AY_FLAG_FORCE_NON_OPAQUE
+| gl_RayFlagsTerminateOnFirstHitEXT | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH
+| gl_RayFlagsSkipClosestHitShaderEXT | RAY_FLAG_SKIP_CLOSEST_HIT_SHADER
+| gl_RayFlagsCullBackFacingTrianglesEXT | RAY_FLAG_CULL_BACK_FACING_TRIANGLES
+| gl_RayFlagsCullFrontFacingTrianglesEXT | RAY_FLAG_CULL_FRONT_FACING_TRIANGLES 
+| gl_RayFlagsCullOpaqueEXT | RAY_FLAG_CULL_OPAQUE
+| gl_RayFlagsCullNoOpaqueEXT | RAY_FLAG_CULL_NON_OPAQUE
+| @todo | RAY_FLAG_SKIP_TRIANGLES
+| @todo | RAY_FLAG_SKIP_PROCEDURAL_PRIMITIVES
+| gl_HitKindFrontFacingTriangleEXT | HIT_KIND_TRIANGLE_FRONT_FACE 
+| gl_HitKindBackFacingTriangleEXT | HIT_KIND_TRIANGLE_BACK_FACE 
+| shadercallcoherent | @todo
+|====
+
+=== Mesh shader
+|====
+| *GLSL*  | *HLSL*
+| EmitMeshTasksEXT | DispatchMesh
+| SetMeshOutputsEXT | SetMeshOutputCounts
+| EmitVertex | TriangleStream<T>.Append
+| EndPrimitive | TriangleStream<T>.RestartStrip
+|====

--- a/chapters/shader_language_decoder_ring.adoc
+++ b/chapters/shader_language_decoder_ring.adoc
@@ -6,6 +6,7 @@ ifndef::images[:images: images/]
 
 [[shader-decoder-ring]]
 = Vulkan High Level Shader Language Decoder Ring
+:toc:
 
 While Vulkan itself consumes shaders as xref:{chapters}what_is_spirv.adoc[SPIR-V] shaders are usually written in a high level language. This section provides a mapping between shader functionality for the most common ones used with Vulkan: GLSL and HLSL. This is mostly aimed at people wanting to migrate from one high level shader language to another. It's meant as a starting point and not as a complete porting guide to one language from another
 

--- a/chapters/shader_language_decoder_ring.adoc
+++ b/chapters/shader_language_decoder_ring.adoc
@@ -131,6 +131,8 @@ VSOutput main(VSInput input) {
 }
 ----
 
+// @todo: add general note on input semantics, e.g. for other stuff like compute where you need to use input semantics instead of built-ins
+
 `+<semantic type>+` can be
 [options="header"]
 |====
@@ -153,9 +155,13 @@ link:https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hl
 
 === Shader outputs
 
-==== GLSL
+==== Passing data between stages
 
-layout (location = __<location index>__) out __<type>__ __<name>__;
+E.g. for vertex and tessellations shaders.
+
+===== GLSL
+
+layout (location = __<location index>__) out/in __<type>__ __<name>__;
 
 Example:
 [source,glsl]
@@ -171,7 +177,7 @@ void main() {
 }
 ----
 
-==== HLSL
+===== HLSL
 
 [[vk::location(__<location index>__)]] __<type>__ __<name>__ : __<semantic type>__;
 
@@ -191,6 +197,50 @@ VSOutput main(VSInput input) {
     VSOutput output = (VSOutput)0;
     output.Pos = float4(input.Pos.xyz, 1.0);
     output.Normal = input.Normal;
+    return output;
+}
+----
+
+==== Writing attachments
+
+For fragment shaders.
+
+===== GLSL
+
+layout (location = __<attachment index>__) out/in __<type>__ __<name>__;
+
+Example:
+[source,glsl]
+----
+layout (location = 0) out vec4 outPosition;
+layout (location = 1) out vec4 outNormal;
+layout (location = 2) out vec4 outAlbedo;
+
+void main() {
+    outPosition = ...
+    outNormal = ...
+    outAlbedo = ...
+}
+----
+
+===== HLSL
+
+__<type>__ __<name>__ : SV_TARGET__<attachment index>__;
+
+Example:
+[source,hlsl]
+----
+struct FSOutput
+{
+	float4 Position : SV_TARGET0;
+	float4 Normal : SV_TARGET1;
+	float4 Albedo : SV_TARGET2;
+};
+
+FSOutput main(VSOutput input) {
+    output.Position = ...
+    output.Normal = ...
+    output.Albedo = ...
     return output;
 }
 ----
@@ -288,10 +338,53 @@ Example:
 void main() {}
 ----
 
+=== Texture reads
+
+[NOTE]
+====
+Where GLSL uses global functions to access images, HLSL uses member functions of the texture object.
+====
+
+Example:
+
+GLSL:
+[source,glsl]
+----
+layout (binding = 0, set = 0) uniform sampler2D sampler0;
+
+void main() {
+    vec4 color = texture(sampler0, inUV);
+}
+----
+
+HLSL:
+[source,hlsl]
+----
+Texture2D texture0 : register(t0, space0);
+SamplerState sampler0 : register(s0, space0);
+
+float4 main(VSOutput input) : SV_TARGET {
+    float4 color = texture0.Sample(sampler0, input.UV);
+}
+----
+
+[options="header"]
+|====
+| *GLSL*  | *HLSL*
+| texture | Sample
+| textureGrad | SampleGrad
+| textureLod | SampleLevel
+| textureSize | GetDimensions
+| textureProj | n.a.
+| texelFetch | Load
+| sparseTexelsResidentARB | SampleLevel
+|====
+
 == Built-ins and functions mapping
-// @todo: change caption
+// @todo: change caption or maybe remove completely
 
 === Raytracing
+[options="header"]
 |====
 | *GLSL*  | *HLSL*
 | accelerationStructureEXT | RaytracingAccelerationStructure
@@ -342,23 +435,88 @@ void main() {}
 | shadercallcoherent | @todo
 |====
 
-=== Mesh shader
+=== Compute
+
+[options="header"]
+|====
+| *GLSL*  | *HLSL*
+| shared | groupshared
+| gl_GlobalInvocationID | SV_DispatchThreadID semantic
+| gl_LocalInvocationID | SV_GroupThreadID semantic
+| gl_WorkGroupSize | n.a.
+|====
+
+==== Barriers
+
+[NOTE]
+====
+Barriers heavily differ between GLSL and HLSL. With one exception there is no direct mapping. To match HLSL in GLSL you often need to call multiple different barrier types in glsl.
+====
+
+Example:
+
+GLSL:
+[source,glsl]
+----
+groupMemoryBarrier();
+barrier();
+for (int j = 0; j < 256; j++) {
+    doSomething();
+}
+groupMemoryBarrier();
+barrier();
+----
+
+HLSL:
+[source,hlsl]
+----
+GroupMemoryBarrierWithGroupSync();
+for (int j = 0; j < 256; j++) {
+    doSomething();
+}
+GroupMemoryBarrierWithGroupSync();
+----
+
+|====
+| *GLSL*  | *HLSL*
+| groupMemoryBarrier | GroupMemoryBarrier
+| groupMemoryBarrier + barrier | GroupMemoryBarrierWithGroupSync
+| memoryBarrier + memoryBarrierImage + memoryBarrierImage | DeviceMemoryBarrier
+| memoryBarrier + memoryBarrierImage + memoryBarrierImage + barrier | DeviceMemoryBarrierWithGroupSync
+| All above barriers + barrier | AllMemoryBarrierWithGroupSync
+| All above barriers | AllMemoryBarrier
+| memoryBarrierShared (only) | n.a.
+|====
+
+=== Mesh, task (amplification) and geometry shaders
+
+These shader stages share several functions and built-ins
+
+[options="header"]
 |====
 | *GLSL*  | *HLSL*
 | EmitMeshTasksEXT | DispatchMesh
 | SetMeshOutputsEXT | SetMeshOutputCounts
-| EmitVertex | TriangleStream<T>.Append
-| EndPrimitive | TriangleStream<T>.RestartStrip
+| EmitVertex | __StreamType__<__Name__>.Append (e.g. +{TriangleStream<MSOutput>}+)
+| EndPrimitive | __StreamType__<__Name__>.RestartStrip
+| gl_in | Array argument for main entry (e.g. +{triangle VSInput input[3]}+)
 |====
 
 === Misc
 // @todo: rename, split
+[options="header"]
 |====
 | *GLSL*  | *HLSL* | *Note*
-| gl_PointSize | [[vk::builtin("PointSize")]] | Vulkan only, not direct HLSL equivalent
-| gl_BaseVertexARB | [[vk::builtin("BaseVertex")]] | Vulkan only, not direct HLSL equivalent
-| gl_BaseInstanceARB | [[vk::builtin("PoBaseInstanceintSize")]] | Vulkan only, not direct HLSL equivalent
-| gl_DrawIDARB | [[vk::builtin("DrawIndex")]] | Vulkan only, not direct HLSL equivalent
-| gl_DeviceIndex | [[vk::builtin("DeviceIndex")]] | Vulkan only, not direct HLSL equivalent
-| subpassLoad | <SubPassInput>.SubpassLoad
+| gl_PointSize | [[vk::builtin("PointSize")]] | Vulkan only, no direct HLSL equivalent
+| gl_BaseVertexARB | [[vk::builtin("BaseVertex")]] | Vulkan only, no direct HLSL equivalent
+| gl_BaseInstanceARB | [[vk::builtin("PoBaseInstanceintSize")]] | Vulkan only, no direct HLSL equivalent
+| gl_DrawIDARB | [[vk::builtin("DrawIndex")]] | Vulkan only, no direct HLSL equivalent
+| gl_DeviceIndex | [[vk::builtin("DeviceIndex")]] | Vulkan only, no direct HLSL equivalent
+| gl_ViewIndex | SV_ViewID semantic
+| subpassLoad | <SubPassInput>.SubpassLoad |
+| imageLoad | RWTexture1D/2D/3D<T>[] |
+| imageStore | RWTexture1D/2D/3D<T>[] |
+| atomicAdd | InterlockedAdd |
+| atomicCompSwap | InterlockedCompareExchange |
+| imageAtomicExchange | InterlockedExchange |
 |====

--- a/chapters/shader_language_decoder_ring.adoc
+++ b/chapters/shader_language_decoder_ring.adoc
@@ -257,9 +257,12 @@ layout (input_attachment_index = 0, binding = 0) uniform subpassInput input0;
 
 ==== HLSL
 
+[[vk::input_attachment_index(__input attachment index__)]][[vk::binding(__binding index__)]] SubpassInput __name__;
+
 Example:
 [source,hlsl]
 ----
+[[vk::input_attachment_index(0)]][[vk::binding(0)]] SubpassInput input0;
 ----
 
 == Built-ins and functions mapping

--- a/chapters/shader_language_decoder_ring.adoc
+++ b/chapters/shader_language_decoder_ring.adoc
@@ -194,6 +194,73 @@ VSOutput main(VSInput input) {
 }
 ----
 
+=== Push constants
+
+==== GLSL
+
+layout (push_constant) uniform __structure type__ { __members__ } __name__
+
+Example:
+[source,glsl]
+----
+layout (push_constant) uniform PushConsts {
+	mat4 matrix;
+} pushConsts;
+----
+
+==== HLSL
+
+[[vk::push_constant]] __structure type__ pushConsts;
+
+[source,hlsl]
+----
+struct PushConsts {
+    float4x4 matrix;
+};
+[[vk::push_constant]] PushConsts pushConsts;
+----
+
+=== Specialization constants
+
+==== GLSL
+
+layout (constant_id = __spec const index__) const int __name__ = __default value__;
+
+Example:
+[source,glsl]
+----
+layout (constant_id = 0) const int SPEC_CONST = 0;
+----
+
+==== HLSL
+
+[[vk::constant_id(__spec const index__)]] const int __name__ = __default value__;
+
+Example:
+[source,hlsl]
+----
+[[vk::constant_id(0)]] const int SPEC_CONST = 0;
+----
+
+=== Sub passes
+
+==== GLSL
+
+layout (input_attachment_index = __input attachment index__, binding = __binding index__) uniform subpassInput __name__;
+
+Example:
+[source,glsl]
+----
+layout (input_attachment_index = 0, binding = 0) uniform subpassInput input0;
+----
+
+==== HLSL
+
+Example:
+[source,hlsl]
+----
+----
+
 == Built-ins and functions mapping
 // @todo: change caption
 
@@ -211,14 +278,14 @@ VSOutput main(VSInput input) {
 | hitAttributeEXT (storage qualifier) | Last argument of ReportHit()
 | callableDataEXT (storage qualifier) | Last argument of CallShader()
 | callableDataInEXT (storage qualifier) | First argument for main entry of callabe stage
-| shaderRecordEXT (decorated buffer) | @todo
+| shaderRecordEXT (decorated buffer) | [[vk::shader_record_ext]] annotation for a ConstantBuffer
 | gl_LaunchIDEXT | DispatchRaysIndex
 | gl_LaunchSizeEXT | DispatchRaysDimensions
 | gl_PrimitiveID | PrimitiveIndex
 | gl_InstanceID | InstanceIndex
 | gl_InstanceCustomIndexEXT | InstanceID
 | gl_GeometryIndexEXT | GeometryIndex
-| gl_VertexIndex | SV_VertexID |
+| gl_VertexIndex | SV_VertexID
 | gl_WorldRayOriginEXT | WorldRayOrigin
 | gl_WorldRayDirectionEXT | WorldRayDirection
 | gl_ObjectRayOriginEXT | ObjectRayOrigin
@@ -255,4 +322,16 @@ VSOutput main(VSInput input) {
 | SetMeshOutputsEXT | SetMeshOutputCounts
 | EmitVertex | TriangleStream<T>.Append
 | EndPrimitive | TriangleStream<T>.RestartStrip
+|====
+
+=== Misc
+// @todo: rename, split
+|====
+| *GLSL*  | *HLSL* | *Note*
+| gl_PointSize | [[vk::builtin("PointSize")]] | Vulkan only, not direct HLSL equivalent
+| gl_BaseVertexARB | [[vk::builtin("BaseVertex")]] | Vulkan only, not direct HLSL equivalent
+| gl_BaseInstanceARB | [[vk::builtin("PoBaseInstanceintSize")]] | Vulkan only, not direct HLSL equivalent
+| gl_DrawIDARB | [[vk::builtin("DrawIndex")]] | Vulkan only, not direct HLSL equivalent
+| gl_DeviceIndex | [[vk::builtin("DeviceIndex")]] | Vulkan only, not direct HLSL equivalent
+| subpassLoad | <SubPassInput>.SubpassLoad
 |====

--- a/chapters/shader_language_decoder_ring.adoc
+++ b/chapters/shader_language_decoder_ring.adoc
@@ -265,6 +265,29 @@ Example:
 [[vk::input_attachment_index(0)]][[vk::binding(0)]] SubpassInput input0;
 ----
 
+=== Compute local size
+
+==== GLSL
+
+layout (local_size_x = __local size x__, local_size_y = __local size y__, local_size_z = __local size z__) in;
+
+Example:
+[source,glsl]
+----
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+----
+
+==== HLSL
+
+[numthreads(__local size x__, __local size y__, __local size z__)] +
+
+Example:
+[source,hlsl]
+----
+[numthreads(1, 1, 1)]
+void main() {}
+----
+
 == Built-ins and functions mapping
 // @todo: change caption
 


### PR DESCRIPTION
**Note: This is still a draft and as such a work-in-progress.**

This PR adds a new chapter that compares HLSL and GLSL from a Vulkan programmer's point-of-view. It compares the syntax differences, type systems and has mappings for functions etc.

I'm not yet 100% happy with the way it's structured, but as far as content goes it's mostly done.

Any feedback is appreciated :)

Refs #218