### PR TITLE
Add VK_KHR_cooperative_matrix to decoder ring

### DIFF
--- a/chapters/decoder_ring.adoc
+++ b/chapters/decoder_ring.adoc
@@ -41,6 +41,10 @@ Not everything will be a perfect 1:1 match, the goal is to give a rough idea whe
             | conditional rendering
                         | predication
                                     |
+| cooperative matrix
+            |
+                        | wave matrix
+                                    | SIMD group matrix
 | depth/stencil attachment
             | depth Attachment and stencil Attachment
                         | depth/stencil view

--- a/lang/jp/chapters/decoder_ring.adoc
+++ b/lang/jp/chapters/decoder_ring.adoc
@@ -40,6 +40,10 @@ ifndef::chapters[:chapters:]
             | conditional rendering
                         | predication
                                     |
+| cooperative matrix
+            |
+                        | wave matrix
+                                    | SIMD group matrix
 | depth/stencil attachment
             | depth Attachment and stencil Attachment
                         | depth/stencil view

--- a/lang/kor/chapters/decoder_ring.adoc
+++ b/lang/kor/chapters/decoder_ring.adoc
@@ -37,6 +37,10 @@ ifndef::images[:images: images/]
             | part of context
                         | command allocator
                                     | command queue
+| cooperative matrix
+            |
+                        | wave matrix
+                                    | SIMD group matrix
 | conditional rendering
             | conditional rendering
                         | predication


### PR DESCRIPTION
I was trying to figure what `VK_KHR_cooperative_matrix` was in other shading languages, decided to add it here