### PR TITLE
Fix barrier code sample: they are function calls

### DIFF
--- a/chapters/high_level_shader_language_comparison.adoc
+++ b/chapters/high_level_shader_language_comparison.adoc
@@ -818,23 +818,23 @@ Example:
 GLSL:
 [source,glsl]
 ----
-groupMemoryBarrier;
-barrier;
+groupMemoryBarrier();
+barrier();
 for (int j = 0; j < 256; j++) {
     doSomething;
 }
-groupMemoryBarrier;
-barrier;
+groupMemoryBarrier();
+barrier();
 ----
 
 HLSL:
 [source,hlsl]
 ----
-GroupMemoryBarrierWithGroupSync;
+GroupMemoryBarrierWithGroupSync();
 for (int j = 0; j < 256; j++) {
     doSomething;
 }
-GroupMemoryBarrierWithGroupSync;
+GroupMemoryBarrierWithGroupSync();
 ----
 
 |====


### PR DESCRIPTION
Add parentheses to indicate a call to the barrier builtin functions. This applies to both GLSL and HLSL.