### PR TITLE
Remove mentions of Google's Stadia platform

### DIFF
--- a/chapters/platforms.adoc
+++ b/chapters/platforms.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 // Required for both single-page and combined guide xrefs to work
@@ -47,10 +47,6 @@ The Nintendo Switch runs an NVIDIA Tegra chipset that supports native Vulkan.
 == QNX
 
 Vulkan is supported on QNX operation system.
-
-== Stadia
-
-Google's Stadia runs on AMD based Linux machines and Vulkan is the required graphics API.
 
 == Windows
 

--- a/chapters/wsi.adoc
+++ b/chapters/wsi.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 ifndef::chapters[:chapters:]
@@ -20,8 +20,7 @@ Each platform that supports a Vulkan Surface has its own way to create a `VkSurf
   * Android - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
   * DirectFB - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
   * Fuchsia - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
-  * Google Games - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateStreamDescriptorSurfaceGGP[vkCreateStreamDescriptorSurfaceGGP]
-  * iOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
+   * iOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
   * macOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
   * Metal - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]
   * VI - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateViSurfaceNN[vkCreateViSurfaceNN]

--- a/lang/jp/chapters/platforms.adoc
+++ b/lang/jp/chapters/platforms.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 // Required for both single-page and combined guide xrefs to work
@@ -46,10 +46,6 @@ Nintendo Switch は、Vulkan をネイティブにサポートする NVIDIA Tegr
 == QNX
 
 QNX オペレーションシステムでは、Vulkan がサポートされています。
-
-== Stadia
-
-Google の Stadia は AMD ベースの Linux マシンで動作し、Vulkan は必須のグラフィックス API です。
 
 == Windows
 

--- a/lang/jp/chapters/wsi.adoc
+++ b/lang/jp/chapters/wsi.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 ifndef::chapters[:chapters:]
@@ -19,7 +19,6 @@ Vulkan Surface をサポートする各プラットフォームは、それぞ�
   * Android - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
   * DirectFB - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
   * Fuchsia - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
-  * Google Games - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateStreamDescriptorSurfaceGGP[vkCreateStreamDescriptorSurfaceGGP]
   * iOS - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
   * macOS - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
   * Metal - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]

--- a/lang/kor/chapters/platforms.adoc
+++ b/lang/kor/chapters/platforms.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 // Required for both single-page and combined guide xrefs to work
@@ -47,10 +47,6 @@ Nintendo Switch는 네이티브 Vulkan을 지원하는 NVIDIA Tegra 칩셋을 �
 == QNX
 
 Vulkan은 QNX 운영 체제에서 지원됩니다.
-
-== Stadia
-
-구글의 스타디아는 AMD 기반 Linux 시스템에서 실행되며, Vulkan은 필수 그래픽 API입니다.
 
 == Windows
 

--- a/lang/kor/chapters/wsi.adoc
+++ b/lang/kor/chapters/wsi.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2024 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 ifndef::chapters[:chapters:]
@@ -20,7 +20,6 @@ Vulkan 서페이스를 지원하는 각 플랫폼은 플랫폼마다 고유의 A
   * Android - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
   * DirectFB - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
   * Fuchsia - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
-  * Google Games - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateStreamDescriptorSurfaceGGP[vkCreateStreamDescriptorSurfaceGGP]
   * iOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
   * macOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
   * Metal - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]


### PR DESCRIPTION
The guide still mentions Google's discontinued Stadia platform. This PR removes all mentions, including the WSI functions. As it's a simple deletion I also did this for the JP and KOR translations.