### PR TITLE
Fixed typo in the Vulkan validation overview article

### DIFF
--- a/chapters/validation_overview.adoc
+++ b/chapters/validation_overview.adoc
@@ -45,7 +45,7 @@ Since Vulkan doesn't do any error checking, it is **very important**, when devel
 
 [NOTE]
 ====
-The Khronos Validation Layer used to consist of multiple layers but now has been unified to a single `VK_LAYER_KHRONOS_validition` layer. link:https://www.lunarg.com/wp-content/uploads/2019/04/UberLayer_V3.pdf[More details explained in LunarG's whitepaper].
+The Khronos Validation Layer used to consist of multiple layers but now has been unified to a single `VK_LAYER_KHRONOS_validation` layer. link:https://www.lunarg.com/wp-content/uploads/2019/04/UberLayer_V3.pdf[More details explained in LunarG's whitepaper].
 ====
 
 === Getting Validation Layers


### PR DESCRIPTION
Fixed a typo in the Note section in the Vulkan validation overview article.