### PR TITLE
Update sync2 examples

### DIFF
--- a/chapters/synchronization_examples.adoc
+++ b/chapters/synchronization_examples.adoc
@@ -1534,10 +1534,15 @@ VkSubmitInfo2KHR renderingSubmitInfo = {
 
 vkQueueSubmit2KHR(renderQueue, &renderingSubmitInfo, ...);
 
+VkSemaphoreSubmitInfoKHR prePresentWaitInfo = {
+    ...
+    .semaphore = renderingCompleteSemaphore,
+    .stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR};
+
 VkSemaphoreSubmitInfoKHR prePresentCompleteInfo = {
     ...
     .semaphore = prePresentCompleteSemaphore,
-    .stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR};
+    .stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR};
 
 VkCommandBufferSubmitInfoKHR prePresentCommandBufferInfo = {
     ...
@@ -1547,7 +1552,7 @@ VkCommandBufferSubmitInfoKHR prePresentCommandBufferInfo = {
 VkSubmitInfo2KHR prePresentSubmitInfo = {
     ...
     .waitSemaphoreInfoCount     = 1,
-    .pWaitSemaphoreInfos        = &renderingCompleteInfo,
+    .pWaitSemaphoreInfos        = &prePresentWaitInfo,
     .commandBufferInfoCount     = 1,
     .pCommandBufferInfos        = &prePresentCommandBufferInfo,
     .signalSemaphoreInfoCount   = 1,


### PR DESCRIPTION
A small fix for one of the sync 2 samples was done on Vulkan-Docs repo. This PR incorporates that fix into the guide version of the sync2 samples.

See https://github.com/KhronosGroup/Vulkan-Docs/issues/2415