### PR TITLE
Fix wrong link on spirv_extensions.adoc

### DIFF
--- a/chapters/spirv_extensions.adoc
+++ b/chapters/spirv_extensions.adoc
@@ -14,7 +14,7 @@ It is important to remember that SPIR-V is an intermediate language and not an A
 
 == SPIR-V Extension Example
 
-For this example, the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_atomic_int64.html[VK_KHR_8bit_storage] and link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] will be used to expose the `UniformAndStorageBuffer8BitAccess` capability. The following is what the SPIR-V disassembled looks like:
+For this example, the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_8bit_storage.html[VK_KHR_8bit_storage] and link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] will be used to expose the `UniformAndStorageBuffer8BitAccess` capability. The following is what the SPIR-V disassembled looks like:
 
 [source,swift]
 ----


### PR DESCRIPTION
Link was pointing to "64 bit atomics" extension instead of "8 bit storage".