### PR TITLE
update spec links to latest spec version

### DIFF
--- a/chapters/atomics.adoc
+++ b/chapters/atomics.adoc
@@ -46,10 +46,10 @@ While both GLSL and SPIR-V support the use of atomic counters, Vulkan does **not
 
 The current extensions that expose additional support for atomics are:
 
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_atomic_int64.html[VK_KHR_shader_atomic_int64]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_image_atomic_int64.html[VK_EXT_shader_image_atomic_int64]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float.html[VK_EXT_shader_atomic_float]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float2.html[VK_EXT_shader_atomic_float2]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_shader_atomic_int64.html[VK_KHR_shader_atomic_int64]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_image_atomic_int64.html[VK_EXT_shader_image_atomic_int64]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_atomic_float.html[VK_EXT_shader_atomic_float]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_atomic_float2.html[VK_EXT_shader_atomic_float2]
 
 Each explained in more details below.
 

--- a/chapters/depth.adoc
+++ b/chapters/depth.adoc
@@ -127,7 +127,7 @@ When clearing, notice that `VkClearValue` is a union and `VkClearDepthStencilVal
 [[pre-rasterization]]
 == Pre-rasterization
 
-In the graphics pipeline, there are a series of link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[pre-rasterization shader stages] that generate primitives to be rasterized. Before reaching the rasterization step, the final `vec4` position (`gl_Position`) of the last pre-rasterization stage runs through link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vertexpostproc[Fixed-Function Vertex Post-Processing].
+In the graphics pipeline, there are a series of link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[pre-rasterization shader stages] that generate primitives to be rasterized. Before reaching the rasterization step, the final `vec4` position (`gl_Position`) of the last pre-rasterization stage runs through link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vertexpostproc[Fixed-Function Vertex Post-Processing].
 
 The following gives a high level overview of the various coordinates name and operations that occur before rasterization.
 
@@ -155,7 +155,7 @@ A few examples where `Zd` is the result of `Zc`/`Wc`:
 [[user-defined-clipping-and-culling]]
 ==== User defined clipping and culling
 
-Using `ClipDistance` and `CullDistance` built-in arrays the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[pre-rasterization shader stages] can set link:https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#User-defined_clipping[user defined clipping and culling].
+Using `ClipDistance` and `CullDistance` built-in arrays the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[pre-rasterization shader stages] can set link:https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#User-defined_clipping[user defined clipping and culling].
 
 In the last pre-rasterization shader stage, these values will be linearly interpolated across the primitive and the portion of the primitive with interpolated distances less than `0` will be considered outside the clip volume. If `ClipDistance` or `CullDistance` are then used by a fragment shader, they contain these linearly interpolated values.
 
@@ -176,7 +176,7 @@ In OpenGL the `view volume` is expressed as
 
 and anything outside of `[-1, 1]` is clipped.
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_depth_clip_control.html[VK_EXT_depth_clip_control] extension was added to allow efficient layering of OpenGL over Vulkan. By setting the `VkPipelineViewportDepthClipControlCreateInfoEXT::negativeOneToOne` to `VK_TRUE` when creating the `VkPipeline` it will use the OpenGL `[-1, 1]` view volume.
+The link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_depth_clip_control.html[VK_EXT_depth_clip_control] extension was added to allow efficient layering of OpenGL over Vulkan. By setting the `VkPipelineViewportDepthClipControlCreateInfoEXT::negativeOneToOne` to `VK_TRUE` when creating the `VkPipeline` it will use the OpenGL `[-1, 1]` view volume.
 
 If `VK_EXT_depth_clip_control` is not available, the link:https://github.com/KhronosGroup/Vulkan-Docs/issues/1054#issuecomment-547202276[workaround currently] is to perform the conversion in the pre-rasterization shader
 
@@ -195,7 +195,7 @@ The list of viewports being used in the pipeline is expressed by `VkPipelineView
 
 [NOTE]
 ====
-The viewport value can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_VIEWPORT` or the `VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT` from link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
+The viewport value can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_VIEWPORT` or the `VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT` from link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
 ====
 
 [[depth-range]]
@@ -208,7 +208,7 @@ Each viewport holds a `VkViewport::minDepth` and `VkViewport::maxDepth` value wh
 Despite their names, `minDepth` can be less than, equal to, or greater than `maxDepth`.
 ====
 
-The `minDepth` and `maxDepth` are restricted to be set inclusively between `0.0` and `1.0`. If the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_depth_range_unrestricted.html[VK_EXT_depth_range_unrestricted] is enabled, this restriction goes away.
+The `minDepth` and `maxDepth` are restricted to be set inclusively between `0.0` and `1.0`. If the link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_depth_range_unrestricted.html[VK_EXT_depth_range_unrestricted] is enabled, this restriction goes away.
 
 The framebuffer depth coordinate `Zf` is represented as:
 
@@ -229,7 +229,7 @@ Zf = Pz * Zd + Oz
 
 The depth values of all fragments generated by the rasterization of a polygon can be offset by a single value that is computed for that polygon. If `VkPipelineRasterizationStateCreateInfo::depthBiasEnable` is `VK_FALSE` at draw time, no depth bias is applied.
 
-Using the `depthBiasConstantFactor`, `depthBiasClamp`, and `depthBiasSlopeFactor` in `VkPipelineRasterizationStateCreateInfo` the depth bias link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-depthbias[can be calculated].
+Using the `depthBiasConstantFactor`, `depthBiasClamp`, and `depthBiasSlopeFactor` in `VkPipelineRasterizationStateCreateInfo` the depth bias link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-depthbias[can be calculated].
 
 [NOTE]
 ====
@@ -238,7 +238,7 @@ Requires the `VkPhysicalDeviceFeatures::depthBiasClamp` feature to be supported 
 
 [NOTE]
 ====
-The depth bias values can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_BIAS` or the `VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT` from link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state2.html[VK_EXT_extended_dynamic_state2].
+The depth bias values can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_BIAS` or the `VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT` from link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state2.html[VK_EXT_extended_dynamic_state2].
 ====
 
 [[post-rasterization]]
@@ -284,9 +284,9 @@ Violating the condition​ yields undefined behavior.
 [[per-sample-processing-and-coverage-mask]]
 === Per-sample processing and coverage mask
 
-The following post-rasterization occurs as a "per-sample" operation. This means when doing link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fragops-covg[multisampling] with a color attachment, any "depth buffer" `VkImage` used as well must also have been created with the same `VkSampleCountFlagBits` value.
+The following post-rasterization occurs as a "per-sample" operation. This means when doing link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fragops-covg[multisampling] with a color attachment, any "depth buffer" `VkImage` used as well must also have been created with the same `VkSampleCountFlagBits` value.
 
-Each fragment has a link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[coverage mask] based on which samples within that fragment are determined to be within the area of the primitive that generated the fragment. If a fragment operation results in all bits of the coverage mask being `0`, the fragment is discarded.
+Each fragment has a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[coverage mask] based on which samples within that fragment are determined to be within the area of the primitive that generated the fragment. If a fragment operation results in all bits of the coverage mask being `0`, the fragment is discarded.
 
 [[resolving-depth-buffer]]
 ==== Resolving depth buffer
@@ -301,11 +301,11 @@ It is possible in Vulkan using the xref:{chapters}extensions/cleanup.adoc#vk_khr
 Requires the `VkPhysicalDeviceFeatures::depthBounds` feature to be supported.
 ====
 
-If `VkPipelineDepthStencilStateCreateInfo::depthBoundsTestEnable` is used to take each `Za` in the depth attachment and check if it is within the range set by `VkPipelineDepthStencilStateCreateInfo::minDepthBounds` and `VkPipelineDepthStencilStateCreateInfo::maxDepthBounds`. If the value is not within the bounds, the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[coverage mask] is set to zero.
+If `VkPipelineDepthStencilStateCreateInfo::depthBoundsTestEnable` is used to take each `Za` in the depth attachment and check if it is within the range set by `VkPipelineDepthStencilStateCreateInfo::minDepthBounds` and `VkPipelineDepthStencilStateCreateInfo::maxDepthBounds`. If the value is not within the bounds, the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[coverage mask] is set to zero.
 
 [NOTE]
 ====
-The depth bound values can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_BOUNDS` or the `VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT` from link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
+The depth bound values can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_BOUNDS` or the `VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT` from link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
 ====
 
 [[depth-test]]
@@ -330,17 +330,17 @@ An example where `depthCompareOp` == `VK_COMPARE_OP_LESS` (`Zf` < `Za`)
 
 [NOTE]
 ====
-The `depthTestEnable` and `depthCompareOp` value can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT` and `VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT` from link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
+The `depthTestEnable` and `depthCompareOp` value can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT` and `VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT` from link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
 ====
 
 [[depth-buffer-writes]]
 ==== Depth Buffer Writes
 
-Even if the depth test passes, if `VkPipelineDepthStencilStateCreateInfo::depthWriteEnable` is set to `VK_FALSE` it will not write the value out to the depth attachment. The main reason for this is because the depth test itself will set the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[coverage mask] which can be used for certain render techniques.
+Even if the depth test passes, if `VkPipelineDepthStencilStateCreateInfo::depthWriteEnable` is set to `VK_FALSE` it will not write the value out to the depth attachment. The main reason for this is because the depth test itself will set the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[coverage mask] which can be used for certain render techniques.
 
 [NOTE]
 ====
-The `depthWriteEnable` value can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT` from link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
+The `depthWriteEnable` value can be set xref:{chapters}dynamic_state.adoc[dynamically] using `VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT` from link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state].
 ====
 
 [[depth-clamping]]

--- a/chapters/descriptor_dynamic_offset.adoc
+++ b/chapters/descriptor_dynamic_offset.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[descriptor-dynamic-offset]]
 = Descriptor Dynamic Offset
 
-Vulkan offers two types of descriptors that allow adjusting the offset at bind time as link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#descriptorsets-binding-dynamicoffsets[defined in the spec].
+Vulkan offers two types of descriptors that allow adjusting the offset at bind time as link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-binding-dynamicoffsets[defined in the spec].
 
 * dynamic uniform buffer (`VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC`)
 * dynamic storage buffer (`VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC`)

--- a/chapters/dynamic_state.adoc
+++ b/chapters/dynamic_state.adoc
@@ -9,7 +9,7 @@ ifndef::images[:images: images/]
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-dynamic-state[Vulkan Spec chapter]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipelines-dynamic-state[Vulkan Spec chapter]
 ====
 
 == Overview
@@ -38,7 +38,7 @@ vkCmdDraw();
 vkEndCommandBuffer();
 ----
 
-When the `VkPipeline` uses link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-dynamic-state[dynamic state], some pipeline information can be omitted at creation time and instead set during recording of the command buffer. The new logical flow is:
+When the `VkPipeline` uses link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipelines-dynamic-state[dynamic state], some pipeline information can be omitted at creation time and instead set during recording of the command buffer. The new logical flow is:
 
 [source,cpp]
 ----
@@ -87,7 +87,7 @@ Some implementations might have a performance loss using some certain `VkDynamic
 [[dynamic-state-lifetime]]
 == Dynamic state lifetime
 
-The spec talks about how there is a link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#dynamic-state-lifetime[dynamic state lifetime]. The following best describes it in some examples:
+The spec talks about how there is a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#dynamic-state-lifetime[dynamic state lifetime]. The following best describes it in some examples:
 
 [source,cpp]
 ----
@@ -130,6 +130,6 @@ vkCmdDraw()
 [[states-that-are-dynamic]]
 == What states are dynamic
 
-The full list of possible dynamic states can be found in link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDynamicState[VkDynamicState].
+The full list of possible dynamic states can be found in link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDynamicState[VkDynamicState].
 
 The `VK_EXT_extended_dynamic_state`, `VK_EXT_extended_dynamic_state2`, `VK_EXT_extended_dynamic_state3`, `VK_EXT_vertex_input_dynamic_state`, `VK_EXT_attachment_feedback_loop_dynamic_state` and `VK_EXT_color_write_enable` extensions were added with the goal to support applications that need to reduce the number of pipeline state objects they compile and bind.

--- a/chapters/enabling_extensions.adoc
+++ b/chapters/enabling_extensions.adoc
@@ -19,7 +19,7 @@ image::{images}enabling_extensions_instance_extension.png[enabling_extensions_in
 
 == Check for support
 
-An application can link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-extensions[query the physical device] first to check if the extension is **supported** with `vkEnumerateInstanceExtensionProperties` or `vkEnumerateDeviceExtensionProperties`.
+An application can link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-extensions[query the physical device] first to check if the extension is **supported** with `vkEnumerateInstanceExtensionProperties` or `vkEnumerateDeviceExtensionProperties`.
 
 [source,cpp]
 ----
@@ -78,7 +78,7 @@ This means after enabling the extension, an application will still need to xref:
 
 == Promotion Process
 
-When minor versions of xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan are released], some extensions are link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[promoted as defined in the spec]. The goal of promotion is to have extended functionality, that the Vulkan Working Group has decided is widely supported, to be in the core Vulkan spec. More details about Vulkan versions can be found in the xref:{chapters}versions.adoc#versions[version chapter].
+When minor versions of xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan are released], some extensions are link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[promoted as defined in the spec]. The goal of promotion is to have extended functionality, that the Vulkan Working Group has decided is widely supported, to be in the core Vulkan spec. More details about Vulkan versions can be found in the xref:{chapters}versions.adoc#versions[version chapter].
 
 An example would be something such as `VK_KHR_get_physical_device_properties2` which is used for most other extensions. In Vulkan 1.0, an application has to query for support of `VK_KHR_get_physical_device_properties2` before being able to call a function such as `vkGetPhysicalDeviceFeatures2KHR`. Starting in Vulkan 1.1, the `vkGetPhysicalDeviceFeatures2` function is guaranteed to be supported.
 
@@ -86,9 +86,9 @@ Another way to look at promotion is with the `VK_KHR_8bit_storage` as an example
 
 === Promotion Change of Behavior
 
-It is important to realize there is a subtle difference for **some** extension that are promoted. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[The spec describes] how promotion **can** involve minor changes such as in the extension's "`Feature advertisement/enablement`". To best describe the subtlety of this, `VK_KHR_8bit_storage` can be used as a use case.
+It is important to realize there is a subtle difference for **some** extension that are promoted. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[The spec describes] how promotion **can** involve minor changes such as in the extension's "`Feature advertisement/enablement`". To best describe the subtlety of this, `VK_KHR_8bit_storage` can be used as a use case.
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_differences_relative_to_vk_khr_8bit_storage[Vulkan spec describes the change] for `VK_KHR_8bit_storage` for Vulkan 1.2 where it states:
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_differences_relative_to_vk_khr_8bit_storage[Vulkan spec describes the change] for `VK_KHR_8bit_storage` for Vulkan 1.2 where it states:
 
 ____
 If the VK_KHR_8bit_storage extension is not supported, support for the SPIR-V StorageBuffer8BitAccess capability in shader modules is optional.
@@ -99,4 +99,4 @@ ____
   * If `VK_KHR_8bit_storage` is found in `vkEnumerateDeviceExtensionProperties` then the `storageBuffer8BitAccess` feature is **guaranteed** to be supported.
   * If `VK_KHR_8bit_storage` is **not** found in `vkEnumerateDeviceExtensionProperties` then the `storageBuffer8BitAccess` feature **might** be supported and can be checked by querying `VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess`.
 
-The list of all feature changes to promoted extensions can be found in the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions[version appendix of the spec].
+The list of all feature changes to promoted extensions can be found in the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions[version appendix of the spec].

--- a/chapters/enabling_features.adoc
+++ b/chapters/enabling_features.adoc
@@ -14,17 +14,17 @@ This section goes over the logistics for enabling features.
 All features in Vulkan can be categorized/found in 3 sections
 
   1. Core 1.0 Features
-  ** These are the set of features that were available from the initial 1.0 release of Vulkan. The list of features can be found in link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceFeatures[VkPhysicalDeviceFeatures]
+  ** These are the set of features that were available from the initial 1.0 release of Vulkan. The list of features can be found in link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceFeatures[VkPhysicalDeviceFeatures]
   2. Future Core Version Features
   ** With Vulkan 1.1+ some new features were added to the core version of Vulkan. To keep the size of `VkPhysicalDeviceFeatures` backward compatible, new structs were created to hold the grouping of features.
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceVulkan11Features[VkPhysicalDeviceVulkan11Features]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceVulkan12Features[VkPhysicalDeviceVulkan12Features]
+  ** link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceVulkan11Features[VkPhysicalDeviceVulkan11Features]
+  ** link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceVulkan12Features[VkPhysicalDeviceVulkan12Features]
   3. Extension Features
   ** Sometimes extensions contain features in order to enable certain aspects of the extension. These are easily found as they are all labeled as `VkPhysicalDevice[ExtensionName]Features`
 
 == How to Enable the Features
 
-All features must be enabled at `VkDevice` creation time inside the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDeviceCreateInfo[VkDeviceCreateInfo] struct.
+All features must be enabled at `VkDevice` creation time inside the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDeviceCreateInfo[VkDeviceCreateInfo] struct.
 
 [NOTE]
 ====

--- a/chapters/extensions/VK_KHR_shader_subgroup_uniform_control_flow.adoc
+++ b/chapters/extensions/VK_KHR_shader_subgroup_uniform_control_flow.adoc
@@ -9,7 +9,7 @@ ifndef::images[:images: ../images/]
 
 == Overview
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_subgroup_uniform_control_flow.html[VK_KHR_shader_subgroup_uniform_control_flow]
+link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_shader_subgroup_uniform_control_flow.html[VK_KHR_shader_subgroup_uniform_control_flow]
 provides stronger guarantees for reconvergence of invocations in a shader. If
 the extension is supported, shaders can be modified to include a new attribute
 that provides the stronger guarantees (see

--- a/chapters/extensions/cleanup.adoc
+++ b/chapters/extensions/cleanup.adoc
@@ -21,7 +21,7 @@ These are extensions that are unofficially called "`cleanup extension`". The Vul
 Promoted to core in Vulkan 1.2
 ====
 
-This extension adds more information to query about each implementation. The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDriverId[VkDriverId] will be a registered vendor's ID for the implementation. The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] displays which version of xref:{chapters}vulkan_cts.adoc#vulkan-cts[the Vulkan Conformance Test Suite] the implementation passed.
+This extension adds more information to query about each implementation. The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDriverId[VkDriverId] will be a registered vendor's ID for the implementation. The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] displays which version of xref:{chapters}vulkan_cts.adoc#vulkan-cts[the Vulkan Conformance Test Suite] the implementation passed.
 
 [[VK_EXT_host_query_reset]]
 == VK_EXT_host_query_reset
@@ -129,12 +129,12 @@ The maintenance extensions add a collection of minor features that were intentio
 
 Currently, there are 6 maintenance extensions. The first 3 were bundled in Vulkan 1.1 as core. All the details for each are well defined in the extension appendix page.
 
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance1[VK_KHR_maintenance1] - core in Vulkan 1.1
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance2[VK_KHR_maintenance2] - core in Vulkan 1.1
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance3[VK_KHR_maintenance3] - core in Vulkan 1.1
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance4[VK_KHR_maintenance4] - core in Vulkan 1.3
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance5[VK_KHR_maintenance5] - extension only
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance6[VK_KHR_maintenance6] - extension only
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance1[VK_KHR_maintenance1] - core in Vulkan 1.1
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance2[VK_KHR_maintenance2] - core in Vulkan 1.1
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance3[VK_KHR_maintenance3] - core in Vulkan 1.1
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance4[VK_KHR_maintenance4] - core in Vulkan 1.3
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance5[VK_KHR_maintenance5] - extension only
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance6[VK_KHR_maintenance6] - extension only
 
 [[pnext-expansions]]
 == pNext Expansions
@@ -242,7 +242,7 @@ void vkBindImageMemory(VkDevice device,
 }
 
 void vkBindImageMemory2(VkDevice device,
-                        uint32_t bindInfoCount, 
+                        uint32_t bindInfoCount,
                         const VkBindImageMemoryInfo* pBindInfos)
 {
     for (uint32_t i = 0; i < bindInfoCount; i++) {

--- a/chapters/extensions/ray_tracing.adoc
+++ b/chapters/extensions/ray_tracing.adoc
@@ -9,11 +9,11 @@ ifndef::images[:images: ../images/]
 
 A set of five interrelated extensions provide ray tracing support in the Vulkan API.
 
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_acceleration_structure.html[VK_KHR_acceleration_structure]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_ray_tracing_pipeline.html[VK_KHR_ray_tracing_pipeline]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_ray_query.html[VK_KHR_ray_query]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_pipeline_library.html[VK_KHR_pipeline_library]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_deferred_host_operations.html[VK_KHR_deferred_host_operations]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_acceleration_structure.html[VK_KHR_acceleration_structure]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_ray_tracing_pipeline.html[VK_KHR_ray_tracing_pipeline]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_ray_query.html[VK_KHR_ray_query]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_pipeline_library.html[VK_KHR_pipeline_library]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_deferred_host_operations.html[VK_KHR_deferred_host_operations]
 
 Additional SPIR-V and GLSL extensions also expose the necessary programmable functionality for shaders:
 

--- a/chapters/extensions/shader_features.adoc
+++ b/chapters/extensions/shader_features.adoc
@@ -170,7 +170,7 @@ Promoted to core in Vulkan 1.2
 link:https://www.khronos.org/blog/comparing-the-vulkan-spir-v-memory-model-to-cs/[Comparing the Vulkan SPIR-V memory model to C's]
 ====
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#memory-model[Vulkan Memory Model] formally defines how to synchronize memory accesses to the same memory locations performed by multiple shader invocations and this extension exposes a boolean to let implementations to indicate support for it. This is important because with many things targeting Vulkan/SPIR-V it is important that any memory transfer operations an application might attempt to optimize doesn't break across implementations.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#memory-model[Vulkan Memory Model] formally defines how to synchronize memory accesses to the same memory locations performed by multiple shader invocations and this extension exposes a boolean to let implementations to indicate support for it. This is important because with many things targeting Vulkan/SPIR-V it is important that any memory transfer operations an application might attempt to optimize doesn't break across implementations.
 
 [[VK_EXT_shader_viewport_index_layer]]
 == VK_EXT_shader_viewport_index_layer

--- a/chapters/formats.adoc
+++ b/chapters/formats.adoc
@@ -7,20 +7,20 @@ ifndef::images[:images: images/]
 [[formats]]
 = Formats
 
-Vulkan formats are used to describe how memory is laid out. This chapter aims to give a high-level overview of the variations of formats in Vulkan and some logistical information for how to use them. All details are already well specified in both the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#formats[Vulkan Spec format chapter] and the link:https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.html[Khronos Data Format Specification].
+Vulkan formats are used to describe how memory is laid out. This chapter aims to give a high-level overview of the variations of formats in Vulkan and some logistical information for how to use them. All details are already well specified in both the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats[Vulkan Spec format chapter] and the link:https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.html[Khronos Data Format Specification].
 
-The most common use case for a `VkFormat` is when creating a `VkImage`. Because the `VkFormat`&#8203;s are well defined, they are also used when describing the memory layout for things such as a `VkBufferView`, xref:{chapters}vertex_input_data_processing.adoc#input-attribute-format[vertex input attribute], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-image-formats[mapping SPIR-V image formats], creating link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html[triangle geometry in a bottom-level acceleration structure], etc.
+The most common use case for a `VkFormat` is when creating a `VkImage`. Because the `VkFormat`&#8203;s are well defined, they are also used when describing the memory layout for things such as a `VkBufferView`, xref:{chapters}vertex_input_data_processing.adoc#input-attribute-format[vertex input attribute], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-image-formats[mapping SPIR-V image formats], creating link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html[triangle geometry in a bottom-level acceleration structure], etc.
 
 [[feature-support]]
 == Feature Support
 
-It is important to understand that "format support" is not a single binary value per format, but rather each format has a set of link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] that each describes which features are supported for a format.
+It is important to understand that "format support" is not a single binary value per format, but rather each format has a set of link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] that each describes which features are supported for a format.
 
-The supported formats may vary across implementations, but a link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#features-required-format-support[minimum set of format features are guaranteed]. An application can link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#formats-properties[query] for the supported format properties.
+The supported formats may vary across implementations, but a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-required-format-support[minimum set of format features are guaranteed]. An application can link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats-properties[query] for the supported format properties.
 
 [NOTE]
 ====
-Both link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_get_physical_device_properties2.html[VK_KHR_get_physical_device_properties2] and link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_format_feature_flags2.html[VK_KHR_format_feature_flags2] expose another way to query for format features.
+Both link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_get_physical_device_properties2.html[VK_KHR_get_physical_device_properties2] and link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_format_feature_flags2.html[VK_KHR_format_feature_flags2] expose another way to query for format features.
 ====
 
 === Format Feature Query Example
@@ -75,7 +75,7 @@ if ((formatProperties3.linearTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_
 
 == Variations of Formats
 
-Formats come in many variations, most can be grouped by the https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_identification_of_formats[name of the format]. When dealing with images, the  link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageAspectFlagBits.html[VkImageAspectFlagBits] values are used to represent which part of the data is being accessed for operations such as clears and copies.
+Formats come in many variations, most can be grouped by the https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_identification_of_formats[name of the format]. When dealing with images, the  link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkImageAspectFlagBits.html[VkImageAspectFlagBits] values are used to represent which part of the data is being accessed for operations such as clears and copies.
 
 === Color
 
@@ -83,40 +83,40 @@ Format with a `R`, `G`, `B` or `A` component and accessed with the `VK_IMAGE_ASP
 
 === Depth and Stencil
 
-Formats with a `D` or `S` component. These formats are link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#formats-depth-stencil[considered opaque] and have special rules when it comes to link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkBufferImageCopy[copy to and from] depth/stencil images.
+Formats with a `D` or `S` component. These formats are link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats-depth-stencil[considered opaque] and have special rules when it comes to link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkBufferImageCopy[copy to and from] depth/stencil images.
 
 Some formats have both a depth and stencil component and can be accessed separately with `VK_IMAGE_ASPECT_DEPTH_BIT` and `VK_IMAGE_ASPECT_STENCIL_BIT`.
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_separate_depth_stencil_layouts.html[VK_KHR_separate_depth_stencil_layouts] and link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_separate_stencil_usage.html[VK_EXT_separate_stencil_usage], which are both promoted to Vulkan 1.2, can be used to have finer control between the depth and stencil components.
+link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_separate_depth_stencil_layouts.html[VK_KHR_separate_depth_stencil_layouts] and link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_separate_stencil_usage.html[VK_EXT_separate_stencil_usage], which are both promoted to Vulkan 1.2, can be used to have finer control between the depth and stencil components.
 ====
 
 More information about depth format can also be found in the xref:{chapters}depth.adoc#depth-formats[depth chapter].
 
 === Compressed
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#compressed_image_formats[Compressed image formats]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#compressed_image_formats[Compressed image formats]
 representation of multiple pixels encoded interdependently within a region.
 
 .Vulkan Compressed Image Formats
 [options="header"]
 |===
 |Format|How to enable
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-bc[BC (Block-Compressed)] |`VkPhysicalDeviceFeatures::textureCompressionBC`
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-etc2[ETC2 and EAC] |`VkPhysicalDeviceFeatures::textureCompressionETC2`
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-astc[ASTC LDR] |`VkPhysicalDeviceFeatures::textureCompressionASTC_LDR`
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-astc[ASTC HDR] |link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_texture_compression_astc_hdr.html[VK_EXT_texture_compression_astc_hdr]
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-pvrtc[PVRTC] | link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_IMG_format_pvrtc.html[VK_IMG_format_pvrtc]
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-bc[BC (Block-Compressed)] |`VkPhysicalDeviceFeatures::textureCompressionBC`
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-etc2[ETC2 and EAC] |`VkPhysicalDeviceFeatures::textureCompressionETC2`
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-astc[ASTC LDR] |`VkPhysicalDeviceFeatures::textureCompressionASTC_LDR`
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-astc[ASTC HDR] |link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_texture_compression_astc_hdr.html[VK_EXT_texture_compression_astc_hdr]
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-pvrtc[PVRTC] | link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_IMG_format_pvrtc.html[VK_IMG_format_pvrtc]
 |===
 
 === Planar
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_sampler_ycbcr_conversion.html[VK_KHR_sampler_ycbcr_conversion] and link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_ycbcr_2plane_444_formats.html[VK_EXT_ycbcr_2plane_444_formats] add xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc#multi-planar-formats[multi-planar formats] to Vulkan. The planes can be accessed separately with `VK_IMAGE_ASPECT_PLANE_0_BIT`, `VK_IMAGE_ASPECT_PLANE_1_BIT`, and `VK_IMAGE_ASPECT_PLANE_2_BIT`.
+link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_sampler_ycbcr_conversion.html[VK_KHR_sampler_ycbcr_conversion] and link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_ycbcr_2plane_444_formats.html[VK_EXT_ycbcr_2plane_444_formats] add xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc#multi-planar-formats[multi-planar formats] to Vulkan. The planes can be accessed separately with `VK_IMAGE_ASPECT_PLANE_0_BIT`, `VK_IMAGE_ASPECT_PLANE_1_BIT`, and `VK_IMAGE_ASPECT_PLANE_2_BIT`.
 
 === Packed
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#formats-packed[Packed formats] are for the purposes of address alignment. As an example, `VK_FORMAT_A8B8G8R8_UNORM_PACK32` and `VK_FORMAT_R8G8B8A8_UNORM` might seem very similar, but when using the formula from the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex-input-extraction[Vertex Input Extraction section of the spec]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats-packed[Packed formats] are for the purposes of address alignment. As an example, `VK_FORMAT_A8B8G8R8_UNORM_PACK32` and `VK_FORMAT_R8G8B8A8_UNORM` might seem very similar, but when using the formula from the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fxvertex-input-extraction[Vertex Input Extraction section of the spec]
 
 ____
 attribAddress = bufferBindingAddress + vertexOffset + attribDesc.offset;
@@ -126,4 +126,4 @@ For `VK_FORMAT_R8G8B8A8_UNORM` the `attribAddress` has to be a multiple of the c
 
 === External
 
-Currently only supported with the `VK_ANDROID_external_memory_android_hardware_buffer` extension. This extension allows Android applications to import implementation-defined external formats to be used with a xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc[VkSamplerYcbcrConversion]. There are many restrictions what are allowed with these external formats which are link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#memory-external-android-hardware-buffer-external-formats[documented in the spec].
+Currently only supported with the `VK_ANDROID_external_memory_android_hardware_buffer` extension. This extension allows Android applications to import implementation-defined external formats to be used with a xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc[VkSamplerYcbcrConversion]. There are many restrictions what are allowed with these external formats which are link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#memory-external-android-hardware-buffer-external-formats[documented in the spec].

--- a/chapters/layers.adoc
+++ b/chapters/layers.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[layers]]
 = Layers
 
-Layers are optional components that augment the Vulkan system. They can intercept, evaluate, and modify existing Vulkan functions on their way from the application down to the hardware. Layer properties can be queried from an application with link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkEnumerateInstanceLayerProperties[vkEnumerateInstanceLayerProperties].
+Layers are optional components that augment the Vulkan system. They can intercept, evaluate, and modify existing Vulkan functions on their way from the application down to the hardware. Layer properties can be queried from an application with link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkEnumerateInstanceLayerProperties[vkEnumerateInstanceLayerProperties].
 
 == Using Layers
 
@@ -22,7 +22,7 @@ Please see the link:https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.ht
 
 == Device Layers Deprecation
 
-There used to be both instance layers and device layers, but device layers were link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation[deprecated] early in Vulkan's life and should be avoided.
+There used to be both instance layers and device layers, but device layers were link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation[deprecated] early in Vulkan's life and should be avoided.
 
 == Creating a Layer
 

--- a/chapters/mapping_data_to_shaders.adoc
+++ b/chapters/mapping_data_to_shaders.adoc
@@ -13,7 +13,7 @@ ifndef::images[:images: images/]
 All SPIR-V assembly was generated with glslangValidator
 ====
 
-This chapter goes over how to link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces[interface Vulkan with SPIR-V] in order to map data. Using the `VkDeviceMemory` objects allocated from `vkAllocateMemory`, it is up to the application to properly map the data from Vulkan such that the SPIR-V shader understands how to consume it correctly.
+This chapter goes over how to link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces[interface Vulkan with SPIR-V] in order to map data. Using the `VkDeviceMemory` objects allocated from `vkAllocateMemory`, it is up to the application to properly map the data from Vulkan such that the SPIR-V shader understands how to consume it correctly.
 
 In core Vulkan, there are 5 fundamental ways to map data from your Vulkan application to interface with SPIR-V:
 
@@ -102,11 +102,11 @@ More information can be found in the xref:{chapters}vertex_input_data_processing
 [[descriptors]]
 == Descriptors
 
-A link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets[resource descriptor] is the core way to map data such as uniform buffers, storage buffers, samplers, etc. to any shader stage in Vulkan. One way to conceptualize a descriptor is by thinking of it as a pointer to memory that the shader can use.
+A link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets[resource descriptor] is the core way to map data such as uniform buffers, storage buffers, samplers, etc. to any shader stage in Vulkan. One way to conceptualize a descriptor is by thinking of it as a pointer to memory that the shader can use.
 
-There are various link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDescriptorType[descriptor types] in Vulkan, each with their own link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-types[detailed description] in what they allow.
+There are various link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDescriptorType[descriptor types] in Vulkan, each with their own link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-types[detailed description] in what they allow.
 
-Descriptors are grouped together in link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-sets[descriptor sets] which get bound to the shader. Even if there is only a single descriptor in the descriptor set, the entire `VkDescriptorSet` is used when binding to the shader.
+Descriptors are grouped together in link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-sets[descriptor sets] which get bound to the shader. Even if there is only a single descriptor in the descriptor set, the entire `VkDescriptorSet` is used when binding to the shader.
 
 === Example
 
@@ -182,9 +182,9 @@ image::{images}mapping_data_to_shaders_descriptor_2.png[mapping_data_to_shaders_
 [[descriptor-types]]
 === Descriptor types
 
-The Vulkan Spec has a link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-storage-class-correspondence[Shader Resource and Storage Class Correspondence] table that describes how each descriptor type needs to be mapped to in SPIR-V.
+The Vulkan Spec has a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-storage-class-correspondence[Shader Resource and Storage Class Correspondence] table that describes how each descriptor type needs to be mapped to in SPIR-V.
 
-The following shows an example of what GLSL and SPIR-V mapping to each of the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-types[descriptor types] looks like.
+The following shows an example of what GLSL and SPIR-V mapping to each of the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-types[descriptor types] looks like.
 
 For GLSL, more information can be found in the link:https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf[GLSL Spec - 12.2.4. Vulkan Only: Samplers, Images, Textures, and Buffers]
 
@@ -461,7 +461,7 @@ More information can be found in the xref:{chapters}push_constants.adoc#push-con
 [[specialization-constants]]
 == Specialization Constants
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-specialization-constants[Specialization constants] are a mechanism allowing a constant value in SPIR-V to be specified at `VkPipeline` creation time. This is powerful as it replaces the idea of doing preprocessor macros in the high level shading language (GLSL, HLSL, etc).
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipelines-specialization-constants[Specialization constants] are a mechanism allowing a constant value in SPIR-V to be specified at `VkPipeline` creation time. This is powerful as it replaces the idea of doing preprocessor macros in the high level shading language (GLSL, HLSL, etc).
 
 === Example
 
@@ -563,13 +563,13 @@ The typical use cases for specialization constants can be best grouped into thre
 [[physical-storage-buffer]]
 == Physical Storage Buffer
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address] extension promoted to Vulkan 1.2 adds the ability to have "`pointers in the shader`". Using the `PhysicalStorageBuffer` storage class in SPIR-V an application can call `vkGetBufferDeviceAddress` which will return the `VkDeviceAddress` to the memory.
+The link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address] extension promoted to Vulkan 1.2 adds the ability to have "`pointers in the shader`". Using the `PhysicalStorageBuffer` storage class in SPIR-V an application can call `vkGetBufferDeviceAddress` which will return the `VkDeviceAddress` to the memory.
 
 While this is a way to map data to the shader, it is not a way to interface with the shader. For example, if an application wants to use this with a uniform buffer it would have to create a `VkBuffer` with both `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` and `VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT`. From here in this example, Vulkan would use a descriptor to interface with the shader, but could then use the physical storage buffer to update the value after.
 
 == Limits
 
-With all the above examples it is important to be aware that there are link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#limits[limits in Vulkan] that expose how much data can be bound at a single time.
+With all the above examples it is important to be aware that there are link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits[limits in Vulkan] that expose how much data can be bound at a single time.
 
   * Input Attributes
   ** `maxVertexInputAttributes`

--- a/chapters/memory_allocation.adoc
+++ b/chapters/memory_allocation.adoc
@@ -15,13 +15,13 @@ It is also worth noting that managing memory is not easy and developers might wa
 
 == Sub-allocation
 
-Sub-allocation is considered to be a first-class approach when working in Vulkan. It is also important to realize there is a link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#limits-maxMemoryAllocationCount[maxMemoryAllocationCount] which creates a limit to the number of simultaneously active allocations an application can use at once. Memory allocation and deallocation at the OS/driver level is likely to be really slow which is another reason for sub-allocation. A Vulkan app should aim to create large allocations and then manage them itself.
+Sub-allocation is considered to be a first-class approach when working in Vulkan. It is also important to realize there is a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-maxMemoryAllocationCount[maxMemoryAllocationCount] which creates a limit to the number of simultaneously active allocations an application can use at once. Memory allocation and deallocation at the OS/driver level is likely to be really slow which is another reason for sub-allocation. A Vulkan app should aim to create large allocations and then manage them itself.
 
 image::{images}memory_allocation_sub_allocation.png[memory_allocation_sub_allocation.png]
 
 == Transfer
 
-The link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#VkPhysicalDeviceType[VkPhysicalDeviceType] advertises two main different types of GPUs, discrete and integrated (also referred to as UMA (unified memory architecture). It is important for performance to understand the difference between the two.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceType[VkPhysicalDeviceType] advertises two main different types of GPUs, discrete and integrated (also referred to as UMA (unified memory architecture). It is important for performance to understand the difference between the two.
 
 Discrete graphics cards contain their own dedicated memory on the device. The data is transferred over a bus (such as PCIe) which is usually a bottleneck due to the physical speed limitation of transferring data. Some physical devices will advertise a queue with a `VK_QUEUE_TRANSFER_BIT` which allows for a dedicated queue for transferring data. The common practice is to create a _staging buffer_ to copy the host data into before sending through a command buffer to copy over to the device local memory.
 

--- a/chapters/pipeline_cache.adoc
+++ b/chapters/pipeline_cache.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[pipeline-cache]]
 = Pipeline Cache
 
-Pipeline caching is a technique used with link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#VkPipelineCache[VkPipelineCache] objects to reuse pipelines that have already been created. Pipeline creation can be somewhat costly - it has to compile the shaders at creation time for example. The big advantage of a pipeline cache is that the pipeline state can be saved to a file to be used between runs of an application, eliminating some of the costly parts of creation. There is a great Khronos presentation on pipeline caching from link:https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/3D-BOF-SIGGRAPH_Jul16.pdf[SIGGRAPH 2016] (link:https://www.youtube.com/watch?v=owuJRPKIUAg&t=1045s[video]) starting on slide 140.
+Pipeline caching is a technique used with link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPipelineCache[VkPipelineCache] objects to reuse pipelines that have already been created. Pipeline creation can be somewhat costly - it has to compile the shaders at creation time for example. The big advantage of a pipeline cache is that the pipeline state can be saved to a file to be used between runs of an application, eliminating some of the costly parts of creation. There is a great Khronos presentation on pipeline caching from link:https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/3D-BOF-SIGGRAPH_Jul16.pdf[SIGGRAPH 2016] (link:https://www.youtube.com/watch?v=owuJRPKIUAg&t=1045s[video]) starting on slide 140.
 
 image::{images}pipeline_cache_cache.png[pipeline_cache_cache.png]
 

--- a/chapters/platforms.adoc
+++ b/chapters/platforms.adoc
@@ -54,4 +54,4 @@ Vulkan is supported on Windows 7, Windows 8, Windows 10, and Windows 11.
 
 == Others
 
-Some embedded systems support Vulkan by allowing presentation link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#display[directly-to-display].
+Some embedded systems support Vulkan by allowing presentation link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#display[directly-to-display].

--- a/chapters/pnext_and_stype.adoc
+++ b/chapters/pnext_and_stype.adoc
@@ -11,7 +11,7 @@ People new to Vulkan will start to notice the `pNext` and `sType` variables all 
 
 == Two Base Structures
 
-The Vulkan API link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#fundamentals-validusage-pNext[provides two base structures], `VkBaseInStructure` and `VkBaseOutStructure`, to be used as a convenient way to iterate through a structure pointer chain.
+The Vulkan API link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-validusage-pNext[provides two base structures], `VkBaseInStructure` and `VkBaseOutStructure`, to be used as a convenient way to iterate through a structure pointer chain.
 
 The `In` of `VkBaseInStructure` refers to the fact `pNext` is a `const *` and are read-only to loader, layers, and driver receiving them. The `Out` of `VkBaseOutStructure` refers the `pNext` being used to return data back to the application.
 

--- a/chapters/portability_initiative.adoc
+++ b/chapters/portability_initiative.adoc
@@ -10,7 +10,7 @@ ifndef::images[:images: images/]
 [NOTE]
 .Notice
 ====
-Currently a provisional link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_portability_subset.html[VK_KHR_portability_subset] extension specification is available with the link:https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_beta.h[vulkan_beta.h] headers. More information can found in the link:https://www.khronos.org/blog/fighting-fragmentation-vulkan-portability-extension-released-implementations-shipping[press release].
+Currently a provisional link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_portability_subset.html[VK_KHR_portability_subset] extension specification is available with the link:https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_beta.h[vulkan_beta.h] headers. More information can found in the link:https://www.khronos.org/blog/fighting-fragmentation-vulkan-portability-extension-released-implementations-shipping[press release].
 ====
 
 The link:https://www.vulkan.org/porting#vulkan-portability-initiative[Vulkan Portability Initiative] is an effort inside the Khronos Group to develop resources to define and evolve the link:https://github.com/KhronosGroup/Vulkan-Portability[subset] of Vulkan capabilities that can be made universally available at native performance levels across all major platforms, including those not currently served by Vulkan native drivers. In a nutshell, this initiative is about making Vulkan viable on platforms that do not natively support the API (e.g MacOS and iOS).

--- a/chapters/protected.adoc
+++ b/chapters/protected.adoc
@@ -12,7 +12,7 @@ Protected memory divides device memory into "`protected device memory`" and "`un
 
 In general, most OS don't allow one application to access another application's GPU memory unless explicitly shared (e.g. via xref:{chapters}extensions/external.adoc#external-memory[external memory]). A common example of protected memory is for containing DRM content, which a process might be allowed to modify (e.g. for image filtering, or compositing playback controls and closed captions) but shouldn' be able to extract into unprotected memory. The data comes in encrypted and remains encrypted until it reaches the pixels on the display.
 
-The Vulkan Spec link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#memory-protected-memory[explains in detail] what "`protected device memory`" enforces. The following is a breakdown of what is required in order to properly enable a protected submission using protected memory.
+The Vulkan Spec link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#memory-protected-memory[explains in detail] what "`protected device memory`" enforces. The following is a breakdown of what is required in order to properly enable a protected submission using protected memory.
 
 == Checking for support
 
@@ -88,7 +88,7 @@ When creating a swapchain the `VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` bit is use
 
 All `VkImage` from `vkGetSwapchainImagesKHR` using a protected swapchain are the same as if the image was created with `VK_IMAGE_CREATE_PROTECTED_BIT`.
 
-Sometimes it is unknown whether swapchains can be created with the `VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` flag set. The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_surface_protected_capabilities.html[VK_KHR_surface_protected_capabilities] extension is exposed on platforms where this might be unknown.
+Sometimes it is unknown whether swapchains can be created with the `VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` flag set. The link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_surface_protected_capabilities.html[VK_KHR_surface_protected_capabilities] extension is exposed on platforms where this might be unknown.
 
 == Protected command buffer
 

--- a/chapters/push_constants.adoc
+++ b/chapters/push_constants.adoc
@@ -33,7 +33,7 @@ A small bank of values writable via the API and accessible in shaders. Push cons
 [[pc-shader-code]]
 === Shader Code
 
-From a shader perspective, push constant are similar to a uniform buffer. The spec provides details for the link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-pushconst[push constant interface] between Vulkan and SPIR-V.
+From a shader perspective, push constant are similar to a uniform buffer. The spec provides details for the link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-pushconst[push constant interface] between Vulkan and SPIR-V.
 
 A simple GLSL fragment shader example (link:https://godbolt.org/z/93WaYd8dE[Try Online]):
 
@@ -68,12 +68,12 @@ Which when looking at parts of the disassembled SPIR-V
 %access_chain   = OpAccessChain %pc_v4float_ptr %pc_var %int_0
 ----
 
-it matches the link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-pushconst[Vulkan spec] description of being an `OpTypeStruct` type with a `Block` decoration.
+it matches the link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-pushconst[Vulkan spec] description of being an `OpTypeStruct` type with a `Block` decoration.
 
 [[pc-pipeline-layout]]
 === Pipeline layout
 
-When calling `vkCreatePipelineLayout` the link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPushConstantRange.html[push constant ranges] needs to be set in link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineLayoutCreateInfo.html[VkPipelineLayoutCreateInfo].
+When calling `vkCreatePipelineLayout` the link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPushConstantRange.html[push constant ranges] needs to be set in link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPipelineLayoutCreateInfo.html[VkPipelineLayoutCreateInfo].
 
 An example using the previous shader above:
 
@@ -99,7 +99,7 @@ vkCreatePipelineLayout(device, &create_info, NULL, &pipeline_layout);
 [[pc-updating]]
 === Updating at record time
 
-Lastly, the value for the push constants needs to be updated to the desired value using link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdPushConstants.html[vkCmdPushConstants].
+Lastly, the value for the push constants needs to be updated to the desired value using link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/vkCmdPushConstants.html[vkCmdPushConstants].
 
 [source,cpp]
 ----
@@ -158,14 +158,14 @@ image::{images}push_constant_offset.png[push_constant_offset]
 [[pc-pipeline-layout-compatibility]]
 == Pipeline layout compatibility
 
-The Vulkan spec defines what link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-compatibility[Compatibility for push constants] as
+The Vulkan spec defines what link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-compatibility[Compatibility for push constants] as
 
 [NOTE]
 ====
 if they were created with identical push constant ranges
 ====
 
-This means before a link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-bindpoint-commands[bound pipeline command is issued] (`vkCmdDraw`, `vkCmdDispatch`, etc) the `VkPipelineLayout` used in the last `vkCmdPushConstants` and `vkCmdBindPipeline` (for the appropriate `VkPipelineBindPoint`) must have had **identical** `VkPushConstantRange`.
+This means before a link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipeline-bindpoint-commands[bound pipeline command is issued] (`vkCmdDraw`, `vkCmdDispatch`, etc) the `VkPipelineLayout` used in the last `vkCmdPushConstants` and `vkCmdBindPipeline` (for the appropriate `VkPipelineBindPoint`) must have had **identical** `VkPushConstantRange`.
 
 [[pc-lifetime]]
 == Lifetime of push constants
@@ -180,7 +180,7 @@ There are some CTS under `dEQP-VK.pipeline.push_constant.lifetime.*`
 [[pc-binding-descriptor-sets]]
 === Binding descriptor sets has no effect
 
-Because push constants are not tied to descriptors, the use of `vkCmdBindDescriptorSets` has no effect on the lifetime or link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-compatibility[pipeline layout compatibility] of push constants.
+Because push constants are not tied to descriptors, the use of `vkCmdBindDescriptorSets` has no effect on the lifetime or link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-compatibility[pipeline layout compatibility] of push constants.
 
 [[pc-mixing-bind-points]]
 === Mixing bind points

--- a/chapters/querying_extensions_features.adoc
+++ b/chapters/querying_extensions_features.adoc
@@ -40,17 +40,17 @@ There are many times when a set of new functionality is desired in Vulkan that d
 Checkout the xref:{chapters}enabling_features.adoc#enabling-features[Enabling Features] chapter for more information.
 ====
 
-Features describe functionality which is not supported on all implementations. Features can be link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkGetPhysicalDeviceFeatures[queried] and then enabled when creating the `VkDevice`. Besides the link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#features[list of all features], some link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-requirements[features are mandatory] due to newer Vulkan versions or use of extensions.
+Features describe functionality which is not supported on all implementations. Features can be link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceFeatures[queried] and then enabled when creating the `VkDevice`. Besides the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features[list of all features], some link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-requirements[features are mandatory] due to newer Vulkan versions or use of extensions.
 
 A common technique is for an extension to expose a new struct that can be passed through `pNext` that adds more features to be queried.
 
 == Limits
 
-Limits are implementation-dependent minimums, maximums, and other device characteristics that an application may need to be aware of. Besides the link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#limits[list of all limits], some limits also have link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#limits-minmax[minimum/maximum required values] guaranteed from a Vulkan implementation.
+Limits are implementation-dependent minimums, maximums, and other device characteristics that an application may need to be aware of. Besides the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits[list of all limits], some limits also have link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-minmax[minimum/maximum required values] guaranteed from a Vulkan implementation.
 
 == Formats
 
-Vulkan provides many `VkFormat` that have multiple `VkFormatFeatureFlags` each holding a various link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] bitmasks that can be queried.
+Vulkan provides many `VkFormat` that have multiple `VkFormatFeatureFlags` each holding a various link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] bitmasks that can be queried.
 
 Checkout the xref:{chapters}formats.adoc#feature-support[Format chapter] for more information.
 

--- a/chapters/queues.adoc
+++ b/chapters/queues.adoc
@@ -32,12 +32,12 @@ Not all applications will require or benefit from multiple queues. It is reasona
 
 There are various types of operations a `VkQueue` can support. A "`Queue Family`" just describes a set of `VkQueue`&#8203;s that have common properties and support the same functionality, as advertised in `VkQueueFamilyProperties`.
 
-The following are the queue operations found in link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkQueueFlagBits.html[VkQueueFlagBits]:
+The following are the queue operations found in link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkQueueFlagBits.html[VkQueueFlagBits]:
 
   * `VK_QUEUE_GRAPHICS_BIT` used for `vkCmdDraw*` and graphic pipeline commands.
   * `VK_QUEUE_COMPUTE_BIT` used for `vkCmdDispatch*` and `vkCmdTraceRays*` and compute pipeline related commands.
   * `VK_QUEUE_TRANSFER_BIT` used for all transfer commands.
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineStageFlagBits.html[VK_PIPELINE_STAGE_TRANSFER_BIT] in the Spec describes "`transfer commands`".
+  ** link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkPipelineStageFlagBits.html[VK_PIPELINE_STAGE_TRANSFER_BIT] in the Spec describes "`transfer commands`".
   ** Queue Families with only `VK_QUEUE_TRANSFER_BIT` are usually for using link:https://en.wikipedia.org/wiki/Direct_memory_access[DMA] to asynchronously transfer data between host and device memory on discrete GPUs, so transfers can be done concurrently with independent graphics/compute operations.
   ** `VK_QUEUE_GRAPHICS_BIT` and `VK_QUEUE_COMPUTE_BIT` can always implicitly accept `VK_QUEUE_TRANSFER_BIT` commands.
   * `VK_QUEUE_SPARSE_BINDING_BIT` used for binding xref:{chapters}sparse_resources.adoc#sparse-resources[sparse resources] to memory with `vkQueueBindSparse`.

--- a/chapters/robustness.adoc
+++ b/chapters/robustness.adoc
@@ -25,37 +25,37 @@ Turning on robustness may incur a runtime performance cost. Application writers 
 
 == What Vulkan provides in core
 
-All Vulkan implementations are required to support the `robustBufferAccess` feature. The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess[spec describes what is considered out-of-bounds] and also how it should be handled. Implementations are given some amount of flexibility for `robustBufferAccess`. An example would be accessing a `vec4(x,y,z,w)` where the `w` value is out-of-bounds as the spec allows the implementation to decide if the `x`, `y`, and `z` are also considered out-of-bounds or not.
+All Vulkan implementations are required to support the `robustBufferAccess` feature. The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess[spec describes what is considered out-of-bounds] and also how it should be handled. Implementations are given some amount of flexibility for `robustBufferAccess`. An example would be accessing a `vec4(x,y,z,w)` where the `w` value is out-of-bounds as the spec allows the implementation to decide if the `x`, `y`, and `z` are also considered out-of-bounds or not.
 
-If dealing with the update after bind functionality found in `VK_EXT_descriptor_indexing` (which is core as of Vulkan 1.2) it is important to be aware of the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#limits-robustBufferAccessUpdateAfterBind[robustBufferAccessUpdateAfterBind] which indicates if an implementation can support both `robustBufferAccess` and the ability to update the descriptor after binding it.
+If dealing with the update after bind functionality found in `VK_EXT_descriptor_indexing` (which is core as of Vulkan 1.2) it is important to be aware of the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-robustBufferAccessUpdateAfterBind[robustBufferAccessUpdateAfterBind] which indicates if an implementation can support both `robustBufferAccess` and the ability to update the descriptor after binding it.
 
-The `robustBufferAccess` feature has some limitations as it only covers buffers and not images. It also allows out-of-bounds writes and atomics to modify the data of the buffer being accessed. For applications looking for a stronger form of robustness, there is link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2].
+The `robustBufferAccess` feature has some limitations as it only covers buffers and not images. It also allows out-of-bounds writes and atomics to modify the data of the buffer being accessed. For applications looking for a stronger form of robustness, there is link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2].
 
-When images are out-of-bounds core Vulkan link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-output-coordinate-validation[provides the guarantee] that stores and atomics have no effect on the memory being accessed.
+When images are out-of-bounds core Vulkan link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#textures-output-coordinate-validation[provides the guarantee] that stores and atomics have no effect on the memory being accessed.
 
 == VK_EXT_image_robustness
 
 === robustImageAccess
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustImageAccess[robustImageAccess] feature in link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_EXT_image_robustness[VK_EXT_image_robustness] enables out-of-bounds checking against the dimensions of the image view being accessed. If there is an out-of-bounds access to any image it will return `(0, 0, 0, 0)` or `(0, 0, 0, 1)`.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustImageAccess[robustImageAccess] feature in link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_EXT_image_robustness[VK_EXT_image_robustness] enables out-of-bounds checking against the dimensions of the image view being accessed. If there is an out-of-bounds access to any image it will return `(0, 0, 0, 0)` or `(0, 0, 0, 1)`.
 
 The `robustImageAccess` feature provides no guarantees about the values returned for access to an invalid LOD, it is still undefined behavior.
 
 == VK_EXT_robustness2
 
-Some applications, such as those being ported from other APIs such as D3D12, require stricter guarantees than `robustBufferAccess` and `robustImageAccess` provide. The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] extension adds this by exposing 3 new robustness features, described in the following sections. For some implementations these extra guarantees can come at a performance cost. Applications that don't need the extra robustness are recommended to use `robustBufferAccess` and/or `robustImageAccess` instead where possible.
+Some applications, such as those being ported from other APIs such as D3D12, require stricter guarantees than `robustBufferAccess` and `robustImageAccess` provide. The link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] extension adds this by exposing 3 new robustness features, described in the following sections. For some implementations these extra guarantees can come at a performance cost. Applications that don't need the extra robustness are recommended to use `robustBufferAccess` and/or `robustImageAccess` instead where possible.
 
 === robustBufferAccess2
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess2[robustBufferAccess2] feature can be seen as a superset of `robustBufferAccess`.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess2[robustBufferAccess2] feature can be seen as a superset of `robustBufferAccess`.
 
-With the feature enabled, it prevents all out-of-bounds writes and atomic from modifying any memory backing buffers. The `robustBufferAccess2` feature also enforces the values that must be returned for the various types of buffers when accessed out-of-bounds as link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess[described in the spec].
+With the feature enabled, it prevents all out-of-bounds writes and atomic from modifying any memory backing buffers. The `robustBufferAccess2` feature also enforces the values that must be returned for the various types of buffers when accessed out-of-bounds as link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess[described in the spec].
 
-It is important to query the `robustUniformBufferAccessSizeAlignment` and `robustStorageBufferAccessSizeAlignment` from link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceRobustness2PropertiesEXT.html[VkPhysicalDeviceRobustness2PropertiesEXT] as the alignment of where buffers are bound-checked is different between implementations.
+It is important to query the `robustUniformBufferAccessSizeAlignment` and `robustStorageBufferAccessSizeAlignment` from link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkPhysicalDeviceRobustness2PropertiesEXT.html[VkPhysicalDeviceRobustness2PropertiesEXT] as the alignment of where buffers are bound-checked is different between implementations.
 
 === robustImageAccess2
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustImageAccess2[robustImageAccess2] feature can be seen as a superset of `robustImageAccess`. It builds on the out-of-bounds checking against the dimensions of the image view being accessed, adding stricter requirements on which values may be returned.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustImageAccess2[robustImageAccess2] feature can be seen as a superset of `robustImageAccess`. It builds on the out-of-bounds checking against the dimensions of the image view being accessed, adding stricter requirements on which values may be returned.
 
 With `robustImageAccess2` an out-of-bounds access to an R, RG, or RGB format will return `(0, 0, 0, 1)`. For an RGBA format, such as `VK_FORMAT_R8G8B8A8_UNORM`, it will return `(0, 0, 0, 0)`.
 
@@ -63,13 +63,13 @@ For the case of accessing an image LOD outside the supported range, with `robust
 
 === nullDescriptor
 
-Without the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-nullDescriptor[nullDescriptor] feature enabled, when updating a `VkDescriptorSet`, all the resources backing it must be non-null, even if the descriptor is statically not used by the shader. This feature allows descriptors to be backed by null resources or views. Loads from a null descriptor return zero values and stores and atomics to a null descriptor are discarded.
+Without the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-nullDescriptor[nullDescriptor] feature enabled, when updating a `VkDescriptorSet`, all the resources backing it must be non-null, even if the descriptor is statically not used by the shader. This feature allows descriptors to be backed by null resources or views. Loads from a null descriptor return zero values and stores and atomics to a null descriptor are discarded.
 
 The `nullDescriptor` feature also allows accesses to vertex input bindings where `vkCmdBindVertexBuffers::pBuffers` is null.
 
 == VK_EXT_pipeline_robustness
 
-Because robustness can come at a performance cost for some implementations, the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_robustness.html[VK_EXT_pipeline_robustness] extension was added to allow developers to request robustness only where needed.
+Because robustness can come at a performance cost for some implementations, the link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_pipeline_robustness.html[VK_EXT_pipeline_robustness] extension was added to allow developers to request robustness only where needed.
 
 At `VkPipeline` creation time one or more `VkPipelineRobustnessCreateInfoEXT` structures can be passed to specify the desired robustness behavior of accesses to buffer, image, and vertex input resources, either for the pipeline as a whole or on a per-pipeline-stage basis.
 

--- a/chapters/shader_memory_layout.adoc
+++ b/chapters/shader_memory_layout.adoc
@@ -8,12 +8,12 @@ ifndef::images[:images: images/]
 [[shader-memory-layout]]
 = Shader Memory Layout
 
-When an implementation accesses memory from an interface, it needs to know the **memory layout**. This includes things such as **offsets**, **stride**, and **alignments**. While the Vulkan Spec has a link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-layout[section dedicated to this], it can be hard to parse due to the various extensions that add extra complexity to the spec language. This chapter aims to help explain all the memory layout concepts Vulkan uses with some high level shading language (GLSL) examples.
+When an implementation accesses memory from an interface, it needs to know the **memory layout**. This includes things such as **offsets**, **stride**, and **alignments**. While the Vulkan Spec has a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-layout[section dedicated to this], it can be hard to parse due to the various extensions that add extra complexity to the spec language. This chapter aims to help explain all the memory layout concepts Vulkan uses with some high level shading language (GLSL) examples.
 
 [[alignment-requirements]]
 == Alignment Requirements
 
-Vulkan has 3 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-alignment-requirements[alignment requirements] that interface objects can be laid out in.
+Vulkan has 3 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-alignment-requirements[alignment requirements] that interface objects can be laid out in.
 
 - extended alignment (also know as `std140`)
 - base alignment (also know as `std430`)
@@ -35,7 +35,7 @@ The spec language for alignment breaks down the rule for each of the following b
 Promoted to core in Vulkan 1.2
 ====
 
-This extension allows the use of `std430` memory layout in UBOs. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-standard-layout[Vulkan Standard Buffer Layout Interface] can be found outside this guide. These memory layout changes are only applied to `Uniforms` as other storage items such as Push Constants and SSBO already allow for std430 style layouts.
+This extension allows the use of `std430` memory layout in UBOs. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-standard-layout[Vulkan Standard Buffer Layout Interface] can be found outside this guide. These memory layout changes are only applied to `Uniforms` as other storage items such as Push Constants and SSBO already allow for std430 style layouts.
 
 One example of when the `uniformBufferStandardLayout` feature is needed is when an application doesn't want the array stride for a UBO to be restricted to `extended alignment`
 

--- a/chapters/sparse_resources.adoc
+++ b/chapters/sparse_resources.adoc
@@ -7,11 +7,11 @@ ifndef::images[:images: images/]
 [[sparse-resources]]
 = Sparse Resources
 
-Vulkan link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory[sparse resources] are a way to create `VkBuffer` and `VkImage` objects which can be bound non-contiguously to one or more `VkDeviceMemory` allocations. There are many aspects and features of sparse resources which the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-sparseresourcefeatures[spec] does a good job explaining. As the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_sparse_resource_implementation_guidelines[implementation guidelines] point out, most implementations use sparse resources to expose a linear virtual address range of memory to the application while mapping each sparse block to physical pages when bound.
+Vulkan link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory[sparse resources] are a way to create `VkBuffer` and `VkImage` objects which can be bound non-contiguously to one or more `VkDeviceMemory` allocations. There are many aspects and features of sparse resources which the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory-sparseresourcefeatures[spec] does a good job explaining. As the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_sparse_resource_implementation_guidelines[implementation guidelines] point out, most implementations use sparse resources to expose a linear virtual address range of memory to the application while mapping each sparse block to physical pages when bound.
 
 == Binding Sparse Memory
 
-Unlike normal resources that call `vkBindBufferMemory()` or `vkBindImageMemory()`, sparse memory is bound via a link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-resource-binding[queue operation] `vkQueueBindSparse()`. The main advantage of this is that an application can rebind memory to a sparse resource throughout its lifetime.
+Unlike normal resources that call `vkBindBufferMemory()` or `vkBindImageMemory()`, sparse memory is bound via a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory-resource-binding[queue operation] `vkQueueBindSparse()`. The main advantage of this is that an application can rebind memory to a sparse resource throughout its lifetime.
 
 It is important to notice that this requires some extra consideration from the application. Applications **must** use synchronization primitives to guarantee that other queues do not access ranges of memory concurrently with a binding change. Also, freeing a `VkDeviceMemory` object with `vkFreeMemory()` will **not** cause resources (or resource regions) bound to the memory object to become unbound. Applications must not access resources bound to memory that has been freed.
 
@@ -33,7 +33,7 @@ image::{images}sparse_resources_buffer.png[sparse_resources_buffer.png]
 
 ==== Mip Tail Regions
 
-Sparse images can be used to update mip levels separately which results in a link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-miptail[mip tail region]. The spec describes the various examples that can occur with diagrams.
+Sparse images can be used to update mip levels separately which results in a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory-miptail[mip tail region]. The spec describes the various examples that can occur with diagrams.
 
 ==== Basic Sparse Resources Example
 

--- a/chapters/spirv_extensions.adoc
+++ b/chapters/spirv_extensions.adoc
@@ -14,7 +14,7 @@ It is important to remember that SPIR-V is an intermediate language and not an A
 
 == SPIR-V Extension Example
 
-For this example, the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_8bit_storage.html[VK_KHR_8bit_storage] and link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] will be used to expose the `UniformAndStorageBuffer8BitAccess` capability. The following is what the SPIR-V disassembled looks like:
+For this example, the link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_8bit_storage.html[VK_KHR_8bit_storage] and link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] will be used to expose the `UniformAndStorageBuffer8BitAccess` capability. The following is what the SPIR-V disassembled looks like:
 
 [source,swift]
 ----
@@ -37,11 +37,11 @@ Breaking down each step in more detail:
 
 Depending on the shader feature there might only be a `OpExtension` or `OpCapability` that is needed. For this example, the `UniformAndStorageBuffer8BitAccess` is part of the link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] extension.
 
-To check if the SPIR-V extension is supported take a look at the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-extensions[Supported SPIR-V Extension Table] in the Vulkan Spec.
+To check if the SPIR-V extension is supported take a look at the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-extensions[Supported SPIR-V Extension Table] in the Vulkan Spec.
 
 image::{images}spirv_extensions_8bit_extension.png[spirv_extensions_8bit_extension]
 
-Also, take a look at the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-capabilities[Supported SPIR-V Capabilities Table] in the Vulkan Spec.
+Also, take a look at the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-capabilities[Supported SPIR-V Capabilities Table] in the Vulkan Spec.
 
 image::{images}spirv_extensions_8bit_capability.png[spirv_extensions_8bit_capability]
 

--- a/chapters/synchronization.adoc
+++ b/chapters/synchronization.adoc
@@ -8,7 +8,7 @@ ifndef::images[:images: images/]
 [[synchronization]]
 = Synchronization
 
-Synchronization is one of the most powerful but also most complex parts of using Vulkan. The application developer is now responsible for managing synchronization using the various link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#synchronization[Vulkan synchronization primitives]. Improper use of synchronization can lead to hard-to-find bugs as well as poor performance in cases where the the GPU is unnecessarily idle.
+Synchronization is one of the most powerful but also most complex parts of using Vulkan. The application developer is now responsible for managing synchronization using the various link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#synchronization[Vulkan synchronization primitives]. Improper use of synchronization can lead to hard-to-find bugs as well as poor performance in cases where the the GPU is unnecessarily idle.
 
 There are a link:https://github.com/KhronosGroup/Vulkan-Docs/wiki/Synchronization-Examples[set of examples] and a link:https://www.khronos.org/blog/understanding-vulkan-synchronization[Understanding Vulkan Synchronization] blog provided by Khronos on how to use some of the synchronization primitives. There are also presentations from Tobias Hector from past Vulkan talks: link:https://www.khronos.org/assets/uploads/developers/library/2017-vulkan-devu-vancouver/009%20-%20Synchronization%20-%20Keeping%20Your%20Device%20Fed.pdf[part 1 slides] (link:https://www.youtube.com/watch?v=YkJ4hKCPjm0[video]) and link:https://www.khronos.org/assets/uploads/developers/library/2018-vulkanised/06-Keeping%20Your%20Device%20Fed%20v4_Vulkanised2018.pdf[part 2 slides] (link:https://www.youtube.com/watch?v=5GDg4OxkSEc[video]).
 
@@ -22,7 +22,7 @@ The Khronos Validation Layer has implemented some link:https://vulkan.lunarg.com
 
 == Pipeline Barriers
 
-link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#synchronization-pipeline-barriers[Pipeline Barriers] give control over which pipeline stages need to wait on previous pipeline stages when a command buffer is executed.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#synchronization-pipeline-barriers[Pipeline Barriers] give control over which pipeline stages need to wait on previous pipeline stages when a command buffer is executed.
 
 image::{images}synchronization_pipeline_barrieres.png[synchronization_pipeline_barrieres.png]
 

--- a/chapters/synchronization_examples.adoc
+++ b/chapters/synchronization_examples.adoc
@@ -731,7 +731,7 @@ vkCreateBuffer(device, &vertexCreateInfo, NULL, &vertexBuffer);
 // VK_MEMORY_PROPERTY_HOST_VISIBLE.
 // Use the example code documented in the description of
 // VkPhysicalDeviceMemoryProperties:
-// https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkPhysicalDeviceMemoryProperties.html
+// https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPhysicalDeviceMemoryProperties.html
 
 ...
 
@@ -776,7 +776,7 @@ Command Buffer Recording and Submission for a unified transfer/graphics queue:
 vkBeginCommandBuffer(...);
 
 // Submission guarantees the host write being complete, as per
-// https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#synchronization-submission-host-writes
+// https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#synchronization-submission-host-writes
 // So no need for a barrier before the transfer
 
 // Copy the staging buffer contents to the vertex buffer
@@ -907,7 +907,7 @@ vkCreateBuffer(device, &vertexCreateInfo, NULL, &vertexBuffer);
 // DEVICE_LOCAL if available.
 // Use the example code documented in the description of
 // VkPhysicalDeviceMemoryProperties:
-// https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkPhysicalDeviceMemoryProperties.html
+// https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPhysicalDeviceMemoryProperties.html
 
 ...
 
@@ -990,7 +990,7 @@ vkCreateImage(device, &imageCreateInfo, NULL, &image);
 // VK_MEMORY_PROPERTY_HOST_VISIBLE.
 // Use the example code documented in the description of
 // VkPhysicalDeviceMemoryProperties:
-// https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkPhysicalDeviceMemoryProperties.html
+// https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPhysicalDeviceMemoryProperties.html
 
 ...
 
@@ -1035,7 +1035,7 @@ Command Buffer Recording and Submission:
 vkBeginCommandBuffer(...);
 
 // Submission guarantees the host write being complete, as per
-// https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#synchronization-submission-host-writes
+// https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#synchronization-submission-host-writes
 // So no need for a barrier before the transfer for that purpose, but one is
 // required for the image layout changes.
 

--- a/chapters/threading.adoc
+++ b/chapters/threading.adoc
@@ -10,13 +10,13 @@ ifndef::images[:images: images/]
 
 One of the big differences between Vulkan and OpenGL is that Vulkan is not limited to a single-threaded state machine system. Before running off to implement threads in an application, it is important to understand how threading works in Vulkan.
 
-The Vulkan Spec link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#fundamentals-threadingbehavior[Threading Behavior section] explains in detail how applications are in charge of managing all _externally synchronized_ elements of Vulkan. It is important to realize that multithreading in Vulkan only provides host-side scaling, as anything interacting with the device still needs to be xref:{chapters}synchronization.adoc#synchronization[synchronized correctly]
+The Vulkan Spec link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-threadingbehavior[Threading Behavior section] explains in detail how applications are in charge of managing all _externally synchronized_ elements of Vulkan. It is important to realize that multithreading in Vulkan only provides host-side scaling, as anything interacting with the device still needs to be xref:{chapters}synchronization.adoc#synchronization[synchronized correctly]
 
 Vulkan implementations are not supposed to introduce any multi-threading, so if an app wants multi-CPU performance, the app is in charge of managing the threading.
 
 == Command Pools
 
-link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#commandbuffers-pools[Command Pools] are a system to allow recording command buffers across multiple threads. A single command pool must be _externally synchronized_; it must not be accessed simultaneously from multiple threads. By using a separate command pool in each host-thread the application can create multiple command buffers in parallel without any costly locks.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#commandbuffers-pools[Command Pools] are a system to allow recording command buffers across multiple threads. A single command pool must be _externally synchronized_; it must not be accessed simultaneously from multiple threads. By using a separate command pool in each host-thread the application can create multiple command buffers in parallel without any costly locks.
 
 The idea is command buffers can be recorded on multiple threads while having a relatively light thread handle the submissions.
 
@@ -26,4 +26,4 @@ Khronos' link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/p
 
 == Descriptor Pools
 
-link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#VkDescriptorPool[Descriptor Pools] are used to allocate, free, reset, and update descriptor sets. By creating multiple descriptor pools, each application host thread is able to manage a descriptor set in each descriptor pool at the same time.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDescriptorPool[Descriptor Pools] are used to allocate, free, reset, and update descriptor sets. By creating multiple descriptor pools, each application host thread is able to manage a descriptor set in each descriptor pool at the same time.

--- a/chapters/validation_overview.adoc
+++ b/chapters/validation_overview.adoc
@@ -15,7 +15,7 @@ The purpose of this section is to give a full overview of how Vulkan deals with 
 
 == Valid Usage (VU)
 
-A **VU** is explicitly link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-validusage[defined in the Vulkan Spec] as:
+A **VU** is explicitly link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-validusage[defined in the Vulkan Spec] as:
 
 [NOTE]
 ====
@@ -36,7 +36,7 @@ When an application supplies invalid input, according to the valid usages in the
 
 A `VUID` is an unique ID given to each valid usage. This allows a way to point to a valid usage in the spec easily.
 
-Using `VUID-vkBindImageMemory-memoryOffset-01046` as an example, it is as simple as adding the VUID to an anchor in the HMTL version of the spec (link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046[vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046]) and it will jump right to the VUID.
+Using `VUID-vkBindImageMemory-memoryOffset-01046` as an example, it is as simple as adding the VUID to an anchor in the HMTL version of the spec (link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046[vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046]) and it will jump right to the VUID.
 
 [[khronos-validation-layer]]
 == Khronos Validation Layer
@@ -63,7 +63,7 @@ The Validation Layers attempt to supply as much useful information as possible w
 
 === Example 1 - Implicit Valid Usage
 
-This example shows a case where an link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-implicit-validity[implicit VU] is triggered. There will not be a number at the end of the VUID.
+This example shows a case where an link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-implicit-validity[implicit VU] is triggered. There will not be a number at the end of the VUID.
 
 [source]
 ----
@@ -77,8 +77,8 @@ html/vkspec.html#VUID-vkBindBufferMemory-memory-parameter)
   * The first thing to notice is the VUID is listed first in the message (`VUID-vkBindBufferMemory-memory-parameter`)
   ** There is also a link at the end of the message to the VUID in the spec
   * `The Vulkan spec states:` is the quoted VUID from the spec.
-  * The `VK_OBJECT_TYPE_INSTANCE` is the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_debugging[VkObjectType]
-  * `Invalid VkDeviceMemory Object 0x60000000006` is the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-objectmodel-overview[Dispatchable Handle] to help show which `VkDeviceMemory` handle was the cause of the error.
+  * The `VK_OBJECT_TYPE_INSTANCE` is the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_debugging[VkObjectType]
+  * `Invalid VkDeviceMemory Object 0x60000000006` is the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-objectmodel-overview[Dispatchable Handle] to help show which `VkDeviceMemory` handle was the cause of the error.
 
 === Example 2 - Explicit Valid Usage
 
@@ -154,7 +154,7 @@ The Validation Layer uses the device properties of the application in order to d
 
 == Special Usage Tags
 
-The link:https://vulkan.lunarg.com/doc/sdk/latest/windows/best_practices.html[Best Practices layer] will produce warnings when an application tries to use any extension with link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-specialuse[special usage tags]. An example of such an extension is xref:{chapters}extensions/translation_layer_extensions.adoc#vk_ext_transform_feedback[VK_EXT_transform_feedback] which is only designed for emulation layers. If an application's intended usage corresponds to one of the special use cases, the following approach will allow you to ignore the warnings.
+The link:https://vulkan.lunarg.com/doc/sdk/latest/windows/best_practices.html[Best Practices layer] will produce warnings when an application tries to use any extension with link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-specialuse[special usage tags]. An example of such an extension is xref:{chapters}extensions/translation_layer_extensions.adoc#vk_ext_transform_feedback[VK_EXT_transform_feedback] which is only designed for emulation layers. If an application's intended usage corresponds to one of the special use cases, the following approach will allow you to ignore the warnings.
 
 Ignoring Special Usage Warnings with `VK_EXT_debug_report`
 

--- a/chapters/versions.adoc
+++ b/chapters/versions.adoc
@@ -8,13 +8,13 @@ ifndef::images[:images: images/]
 [[versions]]
 = Versions
 
-Vulkan works on a link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions-versionnumbers[major, minor, patch] versioning system. Currently, there are 3 minor version releases of Vulkan (1.0, 1.1, 1.2 and 1.3) which are backward compatible with each other. An application can use link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkEnumerateInstanceVersion[vkEnumerateInstanceVersion] to check what version of a Vulkan instance is supported. There is also a link:https://www.lunarg.com/wp-content/uploads/2019/02/Vulkan-1.1-Compatibility-Statement_01_19.pdf[white paper] by LunarG on how to query and check for the supported version. While working across minor versions, there are some subtle things to be aware of.
+Vulkan works on a link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-versionnumbers[major, minor, patch] versioning system. Currently, there are 3 minor version releases of Vulkan (1.0, 1.1, 1.2 and 1.3) which are backward compatible with each other. An application can use link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkEnumerateInstanceVersion[vkEnumerateInstanceVersion] to check what version of a Vulkan instance is supported. There is also a link:https://www.lunarg.com/wp-content/uploads/2019/02/Vulkan-1.1-Compatibility-Statement_01_19.pdf[white paper] by LunarG on how to query and check for the supported version. While working across minor versions, there are some subtle things to be aware of.
 
 == Instance and Device
 
 It is important to remember there is a difference between the instance-level version and device-level version. It is possible that the loader and implementations will support different versions.
 
-The link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions-queryingversionsupport[Querying Version Support] section in the Vulkan Spec goes into details on how to query for supported versions at both the instance and device level.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-queryingversionsupport[Querying Version Support] section in the Vulkan Spec goes into details on how to query for supported versions at both the instance and device level.
 
 == Header
 
@@ -24,7 +24,7 @@ It is highly recommended that developers try to keep up to date with the latest 
 
 == Extensions
 
-Between minor versions of Vulkan, link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#versions-1.1[some extensions] get link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-compatibility-promotions[promoted] to the link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions[core version]. When targeting a newer minor version of Vulkan, an application will not need to enable the newly promoted extensions at the instance and device creation. However, if an application wants to keep backward compatibility, it will need to enable the extensions.
+Between minor versions of Vulkan, link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.1[some extensions] get link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotions[promoted] to the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions[core version]. When targeting a newer minor version of Vulkan, an application will not need to enable the newly promoted extensions at the instance and device creation. However, if an application wants to keep backward compatibility, it will need to enable the extensions.
 
 For a summary of what is new in each version, check out the xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan Release Summary]
 
@@ -54,17 +54,17 @@ The `vkGetPhysicalDeviceFeatures2KHR` function will only exist in a Vulkan 1.0 i
 
 == Features
 
-Between minor versions, it is possible that some feature bits are added, removed, made optional, or made mandatory. All details of features that have changed are described in the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions[Core Revisions] section.
+Between minor versions, it is possible that some feature bits are added, removed, made optional, or made mandatory. All details of features that have changed are described in the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions[Core Revisions] section.
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-requirements[Feature Requirements] section in the Vulkan Spec can be used to view the list of features that are required from implementations across minor versions.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-requirements[Feature Requirements] section in the Vulkan Spec can be used to view the list of features that are required from implementations across minor versions.
 
 == Limits
 
-Currently, all versions of Vulkan share the same minimum/maximum limit requirements, but any changes would be listed in the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#limits-minmax[Limit Requirements] section of the Vulkan Spec.
+Currently, all versions of Vulkan share the same minimum/maximum limit requirements, but any changes would be listed in the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-minmax[Limit Requirements] section of the Vulkan Spec.
 
 == SPIR-V
 
-Every minor version of Vulkan maps to a version of link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#spirvenv[SPIR-V that must be supported].
+Every minor version of Vulkan maps to a version of link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv[SPIR-V that must be supported].
 
   * Vulkan 1.0 supports SPIR-V 1.0
   * Vulkan 1.1 supports SPIR-V 1.3 and below

--- a/chapters/vertex_input_data_processing.adoc
+++ b/chapters/vertex_input_data_processing.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[vertex-input-data-processing]]
 = Vertex Input Data Processing
 
-This chapter is an overview of the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex[Fixed-Function Vertex Processing chapter in the spec] to help give a high level understanding of how an application can map data to the vertex shader when using a graphics pipeline.
+This chapter is an overview of the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fxvertex[Fixed-Function Vertex Processing chapter in the spec] to help give a high level understanding of how an application can map data to the vertex shader when using a graphics pipeline.
 
 It is also important to remember that Vulkan is a tool that can be used in different ways. The following are examples for educational purposes of how vertex data **can** be laid out.
 
@@ -315,7 +315,7 @@ So in this case, the last component of location 1 (`d`) is discarded and would n
 
 == Components Assignment
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex-attrib-location[spec] explains more in detail about the `Component` assignment. The following is a general overview of the topic.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fxvertex-attrib-location[spec] explains more in detail about the `Component` assignment. The following is a general overview of the topic.
 
 
 === Filling in components
@@ -326,7 +326,7 @@ ____
 `VK_FORMAT_R32G32B32_SFLOAT` has 3 components while a `vec2` has only 2
 ____
 
-For the opposite case, the spec link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-conversion-to-rgba[has a table] showing how it will expand missing components.
+For the opposite case, the spec link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#textures-conversion-to-rgba[has a table] showing how it will expand missing components.
 
 This means the example of
 

--- a/chapters/vulkan_cts.adoc
+++ b/chapters/vulkan_cts.adoc
@@ -15,4 +15,4 @@ The link:https://github.com/KhronosGroup/VK-GL-CTS/tree/master/external/vulkanct
 
 image::{images}vulkan_cts_overview.png[vulkan_cts_overview.png]
 
-An application can query the version of CTS passed for an implementation using the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] property via the `VK_KHR_driver_properties` extension (this was promoted to core in Vulkan 1.2).
+An application can query the version of CTS passed for an implementation using the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] property via the `VK_KHR_driver_properties` extension (this was promoted to core in Vulkan 1.2).

--- a/chapters/vulkan_release_summary.adoc
+++ b/chapters/vulkan_release_summary.adoc
@@ -8,7 +8,7 @@ ifndef::images[:images: images/]
 [[vulkan-release-summary]]
 = Vulkan Release Summary
 
-Each minor release version of Vulkan link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[promoted] a different set of extension to core. This means that it's no longer necessary to enable an extensions to use it's functionality if the application requests at least that Vulkan version (given that the version is supported by the implementation).
+Each minor release version of Vulkan link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[promoted] a different set of extension to core. This means that it's no longer necessary to enable an extensions to use it's functionality if the application requests at least that Vulkan version (given that the version is supported by the implementation).
 
 The following summary contains a list of the extensions added to the respective core versions and why they were added. This list is taken from the Vulkan spec, but links jump to the various spots in the Vulkan Guide
 
@@ -16,7 +16,7 @@ The following summary contains a list of the extensions added to the respective 
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.1[Vulkan Spec Section]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.1[Vulkan Spec Section]
 ====
 
 Vulkan 1.1 was released on March 7, 2018
@@ -40,7 +40,7 @@ Besides the listed extensions below, Vulkan 1.1 introduced the xref:{chapters}su
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance1]
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance2]
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance3]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_multiview.html#_description[VK_KHR_multiview]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_multiview.html#_description[VK_KHR_multiview]
   * xref:{chapters}shader_memory_layout.adoc#VK_KHR_relaxed_block_layout[VK_KHR_relaxed_block_layout]
   * xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc#VK_KHR_sampler_ycbcr_conversion[VK_KHR_sampler_ycbcr_conversion]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_draw_parameters[VK_KHR_shader_draw_parameters]
@@ -51,15 +51,15 @@ Besides the listed extensions below, Vulkan 1.1 introduced the xref:{chapters}su
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.2[Vulkan Spec Section]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.2[Vulkan Spec Section]
 ====
 
 Vulkan 1.2 was released on January 15, 2020
 
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_8bit_storage[VK_KHR_8bit_storage]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address]
   * xref:{chapters}extensions/cleanup.adoc#pnext-expansions[VK_KHR_create_renderpass2]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_depth_stencil_resolve.html#_description[VK_KHR_depth_stencil_resolve]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_depth_stencil_resolve.html#_description[VK_KHR_depth_stencil_resolve]
   * xref:{chapters}extensions/VK_KHR_draw_indirect_count.adoc#VK_KHR_draw_indirect_count[VK_KHR_draw_indirect_count]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_driver_properties[VK_KHR_driver_properties]
   * xref:{chapters}extensions/VK_KHR_image_format_list.adoc#VK_KHR_image_format_list[VK_KHR_image_format_list]
@@ -85,7 +85,7 @@ Vulkan 1.2 was released on January 15, 2020
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.3[Vulkan Spec Section]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.3[Vulkan Spec Section]
 ====
 
 Vulkan 1.3 was released on January 25, 2022
@@ -94,7 +94,7 @@ Vulkan 1.3 was released on January 25, 2022
   * link:https://www.khronos.org/blog/streamlining-render-passes[VK_KHR_dynamic_rendering]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_format_feature_flags2[VK_KHR_format_feature_flags2]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_maintenance4[VK_KHR_maintenance4]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_integer_dot_product.html#_description[VK_KHR_shader_integer_dot_product]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_shader_integer_dot_product.html#_description[VK_KHR_shader_integer_dot_product]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_non_semantic_info[VK_KHR_shader_non_semantic_info]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_terminate_invocation[VK_KHR_shader_terminate_invocation]
   * xref:{chapters}extensions/VK_KHR_synchronization2.adoc[VK_KHR_synchronization2]
@@ -103,12 +103,12 @@ Vulkan 1.3 was released on January 25, 2022
   * xref:{chapters}dynamic_state.adoc#states-that-are-dynamic[VK_EXT_extended_dynamic_state]
   * xref:{chapters}dynamic_state.adoc#states-that-are-dynamic[VK_EXT_extended_dynamic_state2]
   * xref:{chapters}extensions/VK_EXT_inline_uniform_block.adoc#VK_EXT_inline_uniform_block[VK_EXT_inline_uniform_block]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_cache_control.html#_description[VK_EXT_pipeline_creation_cache_control]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_feedback.html#_description[VK_EXT_pipeline_creation_feedback]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_private_data.html#_description[VK_EXT_private_data]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_pipeline_creation_cache_control.html#_description[VK_EXT_pipeline_creation_cache_control]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_pipeline_creation_feedback.html#_description[VK_EXT_pipeline_creation_feedback]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_private_data.html#_description[VK_EXT_private_data]
   * xref:{chapters}extensions/shader_features.adoc#VK_EXT_shader_demote_to_helper_invocation[VK_EXT_shader_demote_to_helper_invocation]
   * xref:{chapters}subgroups.adoc#VK_EXT_subgroup_size_control[VK_EXT_subgroup_size_control]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_texel_buffer_alignment.html#_description[VK_EXT_texel_buffer_alignment]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_texture_compression_astc_hdr.html#_description[VK_EXT_texture_compression_astc_hdr]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_tooling_info.html#_description[VK_EXT_tooling_info]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_texel_buffer_alignment.html#_description[VK_EXT_texel_buffer_alignment]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_texture_compression_astc_hdr.html#_description[VK_EXT_texture_compression_astc_hdr]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_tooling_info.html#_description[VK_EXT_tooling_info]
   * xref:{chapters}extensions/cleanup.adoc#VK_EXT_4444_formats-and-VK_EXT_ycbcr_2plane_444_formats[VK_EXT_ycbcr_2plane_444_formats]

--- a/chapters/vulkan_spec.adoc
+++ b/chapters/vulkan_spec.adoc
@@ -19,7 +19,7 @@ Reference the Vulkan Spec early and often.
 
 The Vulkan Spec can be built for any version and with any permutation of extensions. The Khronos Group hosts the link:https://registry.khronos.org/vulkan/specs/[Vulkan Spec Registry] which contains a few publicly available variations that most developers will find sufficient. Anyone can build their own variation of the Vulkan Spec from link:https://github.com/KhronosGroup/Vulkan-Docs/blob/main/BUILD.adoc[Vulkan-Docs].
 
-When building the Vulkan Spec, you pass in what version of Vulkan to build for as well as what extensions to include. A Vulkan Spec without any extensions is also referred to as the link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions[core version] as it is the minimal amount of Vulkan an implementation needs to support in order to be xref:{chapters}vulkan_cts.adoc#vulkan-cts[conformant].
+When building the Vulkan Spec, you pass in what version of Vulkan to build for as well as what extensions to include. A Vulkan Spec without any extensions is also referred to as the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions[core version] as it is the minimal amount of Vulkan an implementation needs to support in order to be xref:{chapters}vulkan_cts.adoc#vulkan-cts[conformant].
 
 == Vulkan Spec Format
 
@@ -104,6 +104,6 @@ Prebuilt PDF Vulkan Spec
 
 === Man pages
 
-The Khronos Group currently only host the Vulkan Man Pages for the latest version of the 1.3 spec, with all extensions, on the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/[online registry].
+The Khronos Group currently only host the Vulkan Man Pages for the latest version of the 1.3 spec, with all extensions, on the link:https://registry.khronos.org/vulkan/specs/latest/man/html/[online registry].
 
 The Vulkan Man Pages can also be found in the VulkanSDK for each SDK version. See the link:https://vulkan.lunarg.com/doc/sdk/latest/windows/apispec.html[Man Pages] for the latest Vulkan SDK.

--- a/chapters/ways_to_provide_spirv.adoc
+++ b/chapters/ways_to_provide_spirv.adoc
@@ -142,7 +142,7 @@ vkCreateShadersEXT(device, 1, &shader_ci, NULL, &shader_object);
 
 When dealing with Ray Tracing pipelines, it is important to note that a `VkDeferredOperationKHR` handle might be used to defer the creation of the pipeline to unblock the CPU thread.
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#deferred-host-operations-requesting[spec states]
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#deferred-host-operations-requesting[spec states]
 
 > Parameters to the command requesting a deferred operation may be accessed by the implementation at any time until the deferred operation enters the complete state.
 

--- a/chapters/what_is_spirv.adoc
+++ b/chapters/what_is_spirv.adoc
@@ -12,14 +12,14 @@ ifndef::images[:images: images/]
 Please read the link:https://github.com/KhronosGroup/SPIRV-Guide[SPIRV-Guide] for more in detail information about SPIR-V
 ====
 
-link:https://registry.khronos.org/SPIR-V/[SPIR-V] is a binary intermediate representation for graphical-shader stages and compute kernels. With Vulkan, an application can still write their shaders in a high-level shading language such as GLSL or xref:{chapters}hlsl.adoc[HLSL], but a SPIR-V binary is needed when using link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkCreateShaderModule[vkCreateShaderModule]. Khronos has a very nice link:https://registry.khronos.org/SPIR-V/papers/WhitePaper.pdf[white paper] about SPIR-V and its advantages, and a high-level description of the representation. There are also two great Khronos presentations from Vulkan DevDay 2016 link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/3-Intro-to-spir-v-shaders.pdf[here] and link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/4-Using-spir-v-with-spirv-cross.pdf[here]
+link:https://registry.khronos.org/SPIR-V/[SPIR-V] is a binary intermediate representation for graphical-shader stages and compute kernels. With Vulkan, an application can still write their shaders in a high-level shading language such as GLSL or xref:{chapters}hlsl.adoc[HLSL], but a SPIR-V binary is needed when using link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateShaderModule[vkCreateShaderModule]. Khronos has a very nice link:https://registry.khronos.org/SPIR-V/papers/WhitePaper.pdf[white paper] about SPIR-V and its advantages, and a high-level description of the representation. There are also two great Khronos presentations from Vulkan DevDay 2016 link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/3-Intro-to-spir-v-shaders.pdf[here] and link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/4-Using-spir-v-with-spirv-cross.pdf[here]
 (link:https://www.youtube.com/watch?v=XRpVwdduzgU[video of both]).
 
 == SPIR-V Interface and Capabilities
 
-Vulkan has an entire section that defines how link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#interfaces[Vulkan interfaces with SPIR-V shaders]. Most valid usages of interfacing with SPIR-V occur during pipeline creation when shaders are compiled together.
+Vulkan has an entire section that defines how link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces[Vulkan interfaces with SPIR-V shaders]. Most valid usages of interfacing with SPIR-V occur during pipeline creation when shaders are compiled together.
 
-SPIR-V has many capabilities as it has other targets than just Vulkan. To see the supported capabilities Vulkan requires, one can reference the link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#spirvenv-capabilities[Appendix]. Some extensions and features in Vulkan are just designed to check if some SPIR-V capabilities are supported or not.
+SPIR-V has many capabilities as it has other targets than just Vulkan. To see the supported capabilities Vulkan requires, one can reference the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-capabilities[Appendix]. Some extensions and features in Vulkan are just designed to check if some SPIR-V capabilities are supported or not.
 
 == Compilers
 

--- a/chapters/what_is_vulkan.adoc
+++ b/chapters/what_is_vulkan.adoc
@@ -16,7 +16,7 @@ Vulkan is not a company, nor language, but rather a way for developers to progra
 
 == Vulkan at its core
 
-At the core, Vulkan is an link:https://registry.khronos.org/vulkan/#apispecs[API Specification] that conformant hardware implementations follow. The public specification is generated from the link:https://github.com/KhronosGroup/Vulkan-Docs/blob/main/xml/vk.xml[./xml/vk.xml] Vulkan Registry file in the official public copy of the Vulkan Specification repo found at link:https://github.com/KhronosGroup/Vulkan-Docs[Vulkan-Doc]. Documentation of the link:https://registry.khronos.org/vulkan/specs/1.3/registry.html[XML schema] is also available.
+At the core, Vulkan is an link:https://registry.khronos.org/vulkan/#apispecs[API Specification] that conformant hardware implementations follow. The public specification is generated from the link:https://github.com/KhronosGroup/Vulkan-Docs/blob/main/xml/vk.xml[./xml/vk.xml] Vulkan Registry file in the official public copy of the Vulkan Specification repo found at link:https://github.com/KhronosGroup/Vulkan-Docs[Vulkan-Doc]. Documentation of the link:https://registry.khronos.org/vulkan/specs/latest/registry.html[XML schema] is also available.
 
 The Khronos Group, along with the Vulkan Specification, releases link:https://www.open-std.org/jtc1/sc22/wg14/www/standards[C99] link:https://github.com/KhronosGroup/Vulkan-Headers/tree/main/include/vulkan[header files] generated from the link:https://registry.khronos.org/vulkan/#apiregistry[API Registry] that developers can use to interface with the Vulkan API.
 

--- a/chapters/what_vulkan_can_do.adoc
+++ b/chapters/what_vulkan_can_do.adoc
@@ -38,16 +38,16 @@ All Vulkan implementations are required to support Compute.
 Ray tracing is an alternative rendering technique, based around the concept of simulating the physical behavior of light.
 
 Cross-vendor API support for ray tracing was added to Vulkan as a set of extensions in the 1.2.162 specification.
-These are primarily link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_ray_query[`VK_KHR_ray_query`], and link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`].
+These are primarily link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_ray_query[`VK_KHR_ray_query`], and link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`].
 
 [NOTE]
 ====
-There is also an older link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_NV_ray_tracing[NVIDIA vendor extension] exposing an implementation of ray tracing on Vulkan. This extension preceded the cross-vendor extensions. For new development, applications are recommended to prefer the more recent KHR extensions.
+There is also an older link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_NV_ray_tracing[NVIDIA vendor extension] exposing an implementation of ray tracing on Vulkan. This extension preceded the cross-vendor extensions. For new development, applications are recommended to prefer the more recent KHR extensions.
 ====
 
 == Video
 
-With the link:https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-decode[Vulkan Video extensions] developers can use hardware accelerated video decoding functionality in realtime. The functionality is exposed through the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_queue.html[VK_KHR_video_queue], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_queue.html[VK_KHR_video_decode_queue], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_h264.html[VK_KHR_video_decode_h264] and link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_h265.html[VK_KHR_video_decode_h265] extensions.
+With the link:https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-decode[Vulkan Video extensions] developers can use hardware accelerated video decoding functionality in realtime. The functionality is exposed through the link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_queue.html[VK_KHR_video_queue], link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_queue.html[VK_KHR_video_decode_queue], link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_h264.html[VK_KHR_video_decode_h264] and link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_h265.html[VK_KHR_video_decode_h265] extensions.
 
 Vulkan Video adheres to the Vulkan philosophy of providing flexible, fine-grained control over video processing scheduling, synchronization, and memory utilization to the application.
 

--- a/chapters/wsi.adoc
+++ b/chapters/wsi.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[wsi]]
 = Window System Integration (WSI)
 
-Since the Vulkan API can be used without displaying results, WSI is provided through the use of link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#wsi[optional Vulkan extensions]. Most implementations will include WSI support. The WSI design was created to abstract each platform's windowing mechanism from the core Vulkan API.
+Since the Vulkan API can be used without displaying results, WSI is provided through the use of link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#wsi[optional Vulkan extensions]. Most implementations will include WSI support. The WSI design was created to abstract each platform's windowing mechanism from the core Vulkan API.
 
 image::{images}wsi_setup.png[wsi_setup]
 
@@ -17,25 +17,25 @@ The `VkSurfaceKHR` object is platform agnostic and designed so the rest of the V
 
 Each platform that supports a Vulkan Surface has its own way to create a `VkSurfaceKHR` object from its respective platform-specific API.
 
-  * Android - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
-  * DirectFB - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
-  * Fuchsia - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
-   * iOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
-  * macOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
-  * Metal - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]
-  * VI - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateViSurfaceNN[vkCreateViSurfaceNN]
-  * Wayland - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkWaylandSurfaceCreateInfoKHR[vkWaylandSurfaceCreateInfoKHR]
-  * QNX - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateScreenSurfaceQNX.html[vkCreateScreenSurfaceQNX]
-  * Windows - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateWin32SurfaceKHR[vkCreateWin32SurfaceKHR]
-  * XCB - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateXcbSurfaceKHR[vkCreateXcbSurfaceKHR]
-  * Xlib - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateXlibSurfaceKHR[vkCreateXlibSurfaceKHR]
-  * Direct-to-Display - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDisplayPlaneSurfaceKHR[vkCreateDisplayPlaneSurfaceKHR]
+  * Android - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
+  * DirectFB - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
+  * Fuchsia - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
+   * iOS - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
+  * macOS - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
+  * Metal - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]
+  * VI - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateViSurfaceNN[vkCreateViSurfaceNN]
+  * Wayland - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkWaylandSurfaceCreateInfoKHR[vkWaylandSurfaceCreateInfoKHR]
+  * QNX - link:https://registry.khronos.org/vulkan/specs/latest/man/html/vkCreateScreenSurfaceQNX.html[vkCreateScreenSurfaceQNX]
+  * Windows - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateWin32SurfaceKHR[vkCreateWin32SurfaceKHR]
+  * XCB - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateXcbSurfaceKHR[vkCreateXcbSurfaceKHR]
+  * Xlib - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateXlibSurfaceKHR[vkCreateXlibSurfaceKHR]
+  * Direct-to-Display - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateDisplayPlaneSurfaceKHR[vkCreateDisplayPlaneSurfaceKHR]
 
-Once a `VkSurfaceKHR` is created there are various link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfaceCapabilitiesKHR[capabilities], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfaceFormatsKHR[formats], and link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfacePresentModesKHR[presentation modes] to query for.
+Once a `VkSurfaceKHR` is created there are various link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfaceCapabilitiesKHR[capabilities], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfaceFormatsKHR[formats], and link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfacePresentModesKHR[presentation modes] to query for.
 
 == Swapchain
 
-The `VkSwapchainKHR` object provides the ability to present rendering results to a surface through an array of `VkImage` objects. The swapchain's various link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPresentModeKHR[present modes] determine how the presentation engine is implemented.
+The `VkSwapchainKHR` object provides the ability to present rendering results to a surface through an array of `VkImage` objects. The swapchain's various link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPresentModeKHR[present modes] determine how the presentation engine is implemented.
 
 image::{images}wsi_engine.png[wsi_engine]
 
@@ -45,4 +45,4 @@ Khronos' link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/p
 
 Mobile devices can be rotated, therefore the logical orientation of the application window and the physical orientation of the display may not match. Applications need to be able to operate in two modes: `portrait` and `landscape`. The difference between these two modes can be simplified to just a change in resolution. However, some display subsystems always work on the "`native`" (or "`physical`") orientation of the display panel. Since the device has been rotated, to achieve the desired effect the application output must also rotate.
 
-In order for your application to get the most out of Vulkan on mobile platforms, such as Android, implementing pre-rotation is a must. There is a link:https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html?m=1[detailed blog post from Google] that goes over how to handle the surface rotation by specifying the orientation during swapchain creation and also comes with a link:https://github.com/google/vulkan-pre-rotation-demo[standalone example]. The link:https://github.com/KhronosGroup/Vulkan-Samples[Vulkan-Samples] also has both a link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[great write up] of why pre-rotation is a problem as well as link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[a sample to run] that shows a way to solve it in the shader. If using an Adreno GPU powered device, Qualcomm suggests making use of the link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_QCOM_render_pass_transform.html[VK_QCOM_render_pass_transform] extension to implement pre-rotation.
+In order for your application to get the most out of Vulkan on mobile platforms, such as Android, implementing pre-rotation is a must. There is a link:https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html?m=1[detailed blog post from Google] that goes over how to handle the surface rotation by specifying the orientation during swapchain creation and also comes with a link:https://github.com/google/vulkan-pre-rotation-demo[standalone example]. The link:https://github.com/KhronosGroup/Vulkan-Samples[Vulkan-Samples] also has both a link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[great write up] of why pre-rotation is a problem as well as link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[a sample to run] that shows a way to solve it in the shader. If using an Adreno GPU powered device, Qualcomm suggests making use of the link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_QCOM_render_pass_transform.html[VK_QCOM_render_pass_transform] extension to implement pre-rotation.

--- a/lang/jp/chapters/atomics.adoc
+++ b/lang/jp/chapters/atomics.adoc
@@ -45,10 +45,10 @@ GLSL と SPIR-V の両方がアトミックカウンタをサポートしてい�
 
 アトミックの追加サポートを公開している現在の拡張機能は以下の通りです。
 
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_atomic_int64.html[VK_KHR_shader_atomic_int64]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_image_atomic_int64.html[VK_EXT_shader_image_atomic_int64]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float.html[VK_EXT_shader_atomic_float]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float2.html[VK_EXT_shader_atomic_float2]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_shader_atomic_int64.html[VK_KHR_shader_atomic_int64]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_shader_image_atomic_int64.html[VK_EXT_shader_image_atomic_int64]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_shader_atomic_float.html[VK_EXT_shader_atomic_float]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_shader_atomic_float2.html[VK_EXT_shader_atomic_float2]
 
 それぞれの詳細は以下の通りです。
 

--- a/lang/jp/chapters/depth.adoc
+++ b/lang/jp/chapters/depth.adoc
@@ -126,7 +126,7 @@ destinationStage = VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR | VK_PIPELIN
 [[pre-rasterization]]
 == ラスタライズの前
 
-グラフィックスパイプラインには、ラスタライズされるべきプリミティブを生成する一連のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[ラスタライズ前のシェーダステージ]があります。ラスタライズステップに到達する前に、ラスタライズ前の最後のステージの最終的な `vec4` 型の位置（`gl_Position`）は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vertexpostproc[Fixed-Function Vertex Post-Processing] を実行します。
+グラフィックスパイプラインには、ラスタライズされるべきプリミティブを生成する一連のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[ラスタライズ前のシェーダステージ]があります。ラスタライズステップに到達する前に、ラスタライズ前の最後のステージの最終的な `vec4` 型の位置（`gl_Position`）は、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vertexpostproc[Fixed-Function Vertex Post-Processing] を実行します。
 
 以下は、ラスタライズの前に行われるさまざまな座標名と操作についての高レベルの概要です。
 
@@ -154,7 +154,7 @@ xref:{chapters}extensions/translation_layer_extensions.adoc#vk_ext_depth_clip_en
 [[user-defined-clipping-and-culling]]
 ==== ユーザー定義のクリッピングとカリング
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[ラスタライズ前のシェーダステージ]では、`ClipDistance` と `CullDistance` の組み込み配列を使って、link:https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#User-defined_clipping[ユーザー定義のクリッピングとカリング]を設定することができます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[ラスタライズ前のシェーダステージ]では、`ClipDistance` と `CullDistance` の組み込み配列を使って、link:https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#User-defined_clipping[ユーザー定義のクリッピングとカリング]を設定することができます。
 
 ラスタライズ前の最後のシェーダステージでは、これらの値はプリミティブ全体で線形補間され、補間された距離が `0` よりも小さいプリミティブの部分はクリップボリュームの外側とみなされます。フラグメントシェーダで `ClipDistance` や `CullDistance` が使用される場合、これらの線形補間された値が含まれます。
 
@@ -175,7 +175,7 @@ OpenGLでは、`view volume` は次のように表されます。
 
 `[-1, 1]` の外側にあるものはクリップされます。
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_depth_clip_control.html[VK_EXT_depth_clip_control] 拡張機能は、Vulkan 上で OpenGL を効率的にレイヤ化するために追加されました。`VkPipeline` の作成時に `VkPipelineViewportDepthClipControlCreateInfoEXT::negativeOneToOne` を `VK_TRUE` に設定すると、OpenGL `[-1, 1]` ビューボリュームを使用するようになります。
+link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_depth_clip_control.html[VK_EXT_depth_clip_control] 拡張機能は、Vulkan 上で OpenGL を効率的にレイヤ化するために追加されました。`VkPipeline` の作成時に `VkPipelineViewportDepthClipControlCreateInfoEXT::negativeOneToOne` を `VK_TRUE` に設定すると、OpenGL `[-1, 1]` ビューボリュームを使用するようになります。
 
 `VK_EXT_depth_clip_control` が利用できない場合、link:https://github.com/KhronosGroup/Vulkan-Docs/issues/1054#issuecomment-547202276[現在の回避策]はラスタライズ前のシェーダで変換を実行することです。
 
@@ -194,7 +194,7 @@ position.z = (position.z + position.w) * 0.5;
 
 [NOTE]
 ====
-ビューポートの値は、`VK_DYNAMIC_STATE_VIEWPORT` または link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT` を使って動的に設定することができます。
+ビューポートの値は、`VK_DYNAMIC_STATE_VIEWPORT` または link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT` を使って動的に設定することができます。
 ====
 
 [[depth-range]]
@@ -207,7 +207,7 @@ position.z = (position.z + position.w) * 0.5;
 名前に反して、`minDepth` は `maxDepth` よりも小さくても、等しくても、大きくても問題ありません。
 ====
 
-`minDepth` と `maxDepth` は、`0.0` から `1.0` に含まれるように制限されています。link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_depth_range_unrestricted.html[VK_EXT_depth_range_unrestricted] が有効な場合、この制限はなくなります。
+`minDepth` と `maxDepth` は、`0.0` から `1.0` に含まれるように制限されています。link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_depth_range_unrestricted.html[VK_EXT_depth_range_unrestricted] が有効な場合、この制限はなくなります。
 
 フレームバッファの深度座標 `Zf` は次のように表される。
 
@@ -228,7 +228,7 @@ Zf = Pz * Zd + Oz
 
 ポリゴンのラスタライズによって生成されたすべてのフラグメントの深度値は、そのポリゴンに対して計算された単一の値によってオフセットすることができます。描画時に `VkPipelineRasterizationStateCreateInfo::depthBiasEnable` が `VK_FALSE` である場合、深度バイアスは適用されません。
 
-`VkPipelineRasterizationStateCreateInfo` の `depthBiasConstantFactor`、`depthBiasClamp`、`depthBiasSlopeFactor` を使って、深度バイアスをlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-depthbias[算出することができます]。
+`VkPipelineRasterizationStateCreateInfo` の `depthBiasConstantFactor`、`depthBiasClamp`、`depthBiasSlopeFactor` を使って、深度バイアスをlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#primsrast-depthbias[算出することができます]。
 
 [NOTE]
 ====
@@ -237,7 +237,7 @@ Zf = Pz * Zd + Oz
 
 [NOTE]
 ====
-深度バイアス値は、`VK_DYNAMIC_STATE_DEPTH_BIAS` または link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state2.html[VK_EXT_extended_dynamic_state2] の `VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT` を使ってxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
+深度バイアス値は、`VK_DYNAMIC_STATE_DEPTH_BIAS` または link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state2.html[VK_EXT_extended_dynamic_state2] の `VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT` を使ってxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
 ====
 
 [[post-rasterization]]
@@ -283,9 +283,9 @@ layout(depth_unchanged) out float gl_FragDepth;
 [[per-sample-processing-and-coverage-mask]]
 === サンプル毎の処理とカバレッジマスク
 
-次のラスタライズ後の処理は、「サンプルごと」に行われます。つまり、カラーアタッチメントを使用してlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fragops-covg[マルチサンプリング]を行う場合、同様に使用される「深度バッファ」 `VkImage` も、同じ `VkSampleCountFlagBits` 値で作成されていなければなりません。
+次のラスタライズ後の処理は、「サンプルごと」に行われます。つまり、カラーアタッチメントを使用してlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fragops-covg[マルチサンプリング]を行う場合、同様に使用される「深度バッファ」 `VkImage` も、同じ `VkSampleCountFlagBits` 値で作成されていなければなりません。
 
-各フラグメントには、そのフラグメント内のサンプルが、そのフラグメントを生成したプリミティブの領域内にあると判断されるlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[カバレッジマスク]が設定されています。フラグメント操作の結果、カバレッジマスクのすべてのビットが `0` になった場合、そのフラグメントは破棄されます。
+各フラグメントには、そのフラグメント内のサンプルが、そのフラグメントを生成したプリミティブの領域内にあると判断されるlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[カバレッジマスク]が設定されています。フラグメント操作の結果、カバレッジマスクのすべてのビットが `0` になった場合、そのフラグメントは破棄されます。
 
 [[resolving-depth-buffer]]
 ==== 深度バッファの解決
@@ -300,11 +300,11 @@ xref:{chapters}extensions/cleanup.adoc#vk_khr_depth_stencil_resolve[VK_KHR_depth
 `VkPhysicalDeviceFeatures::depthBounds` の機能がサポートされている必要があります。
 ====
 
-`VkPipelineDepthStencilStateCreateInfo::depthBoundsTestEnable` が使用されると、深度アタッチメントの各 `Za` を取り、それが `VkPipelineDepthStencilStateCreateInfo::minDepthBounds` および `VkPipelineDepthStencilStateCreateInfo::maxDepthBounds` によって設定された範囲内にあるかどうかをチェックします。値が境界内にない場合は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[カバレッジマスク]はゼロに設定されます。
+`VkPipelineDepthStencilStateCreateInfo::depthBoundsTestEnable` が使用されると、深度アタッチメントの各 `Za` を取り、それが `VkPipelineDepthStencilStateCreateInfo::minDepthBounds` および `VkPipelineDepthStencilStateCreateInfo::maxDepthBounds` によって設定された範囲内にあるかどうかをチェックします。値が境界内にない場合は、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[カバレッジマスク]はゼロに設定されます。
 
 [NOTE]
 ====
-深度境界値は、`VK_DYNAMIC_STATE_DEPTH_BOUNDS` または link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT` を使ってxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
+深度境界値は、`VK_DYNAMIC_STATE_DEPTH_BOUNDS` または link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT` を使ってxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
 ====
 
 [[depth-test]]
@@ -329,17 +329,17 @@ image::../../../chapters/images/depth_test.png[depth_test]
 
 [NOTE]
 ====
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT` と `VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT` を使って、 `depthTestEnable` と `depthCompareOp` の値をxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT` と `VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT` を使って、 `depthTestEnable` と `depthCompareOp` の値をxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
 ====
 
 [[depth-buffer-writes]]
 ==== 深度バッファの書き込み
 
-深度テストに合格しても、`VkPiplineDexpersStencilStateCreateInfo::depthWriteEnable` が `VK_FALSE` に設定されていると、深度アタッチメントに値が書き込まれません。この主な理由は、深度テスト自体が、特定のレンダリング技術に使用できるlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[カバレッジマスク]を設定するためです。
+深度テストに合格しても、`VkPiplineDexpersStencilStateCreateInfo::depthWriteEnable` が `VK_FALSE` に設定されていると、深度アタッチメントに値が書き込まれません。この主な理由は、深度テスト自体が、特定のレンダリング技術に使用できるlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[カバレッジマスク]を設定するためです。
 
 [NOTE]
 ====
-`depthWriteEnable` の値は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT` を使ってxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
+`depthWriteEnable` の値は、link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] の `VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT` を使ってxref:{chapters}dynamic_state.adoc[動的に]設定することができます。
 ====
 
 [[depth-clamping]]

--- a/lang/jp/chapters/descriptor_dynamic_offset.adoc
+++ b/lang/jp/chapters/descriptor_dynamic_offset.adoc
@@ -6,7 +6,7 @@ ifndef::chapters[:chapters:]
 [[descriptor-dynamic-offset]]
 = ディスクリプタ動的オフセット
 
-Vulkanは、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#descriptorsets-binding-dynamicoffsets[仕様で定義されている]ように、バインド時にオフセットを調整できる2種類のディスクリプタを提供しています。
+Vulkanは、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-binding-dynamicoffsets[仕様で定義されている]ように、バインド時にオフセットを調整できる2種類のディスクリプタを提供しています。
 
 * 動的ユニフォームバッファ (`VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC`)
 * 動的ストレージバッファ (`VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC`)

--- a/lang/jp/chapters/dynamic_state.adoc
+++ b/lang/jp/chapters/dynamic_state.adoc
@@ -8,7 +8,7 @@ ifndef::chapters[:chapters:]
 
 [NOTE]
 ====
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-dynamic-state[Vulkan Spec の章]
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipelines-dynamic-state[Vulkan Spec の章]
 ====
 
 == 概要
@@ -37,7 +37,7 @@ vkCmdDraw();
 vkEndCommandBuffer();
 ----
 
-`VkPipeline` がlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-dynamic-state[動的な状態]を使用している場合、一部のパイプライン情報を作成時に省略し、代わりにコマンドバッファの記録時に設定することができます。新しいフローは以下のようになります。
+`VkPipeline` がlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipelines-dynamic-state[動的な状態]を使用している場合、一部のパイプライン情報を作成時に省略し、代わりにコマンドバッファの記録時に設定することができます。新しいフローは以下のようになります。
 
 [source,cpp]
 ----
@@ -86,7 +86,7 @@ Vulkan はツールなので、他のものと同様に、唯一の答えはあ�
 [[dynamic-state-lifetime]]
 == 動的な状態の寿命
 
-仕様書では、link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#dynamic-state-lifetime[動的な状態の寿命]について言及している。以下、いくつかの例を挙げて説明する：
+仕様書では、link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#dynamic-state-lifetime[動的な状態の寿命]について言及している。以下、いくつかの例を挙げて説明する：
 
 
 [source,cpp]
@@ -130,6 +130,6 @@ vkCmdDraw()
 [[states-that-are-dynamic]]
 == 動的な状態とは
 
-動的にすることができる状態のリストは、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkDynamicState[VkDynamicState] にあります。
+動的にすることができる状態のリストは、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkDynamicState[VkDynamicState] にあります。
 
 `VK_EXT_extended_dynamic_state`、`VK_EXT_extended_dynamic_state2`、`VK_EXT_extended_dynamic_state3`、 `VK_EXT_vertex_input_dynamic_state`、 `VK_EXT_attachment_feedback_loop_dynamic_state`、`VK_EXT_color_write_enable` 拡張機能は、コンパイルしてバインドするパイプライン状態オブジェクトの数を減らすために追加されました。

--- a/lang/jp/chapters/enabling_extensions.adoc
+++ b/lang/jp/chapters/enabling_extensions.adoc
@@ -18,7 +18,7 @@ image::../../../chapters/images/enabling_extensions_instance_extension.png[enabl
 
 == 対応の確認
 
-アプリケーションは、まずlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-extensions[物理デバイスにクエリ]し、`vkEnumerateInstanceExtensionProperties` または `vkEnumerateDeviceExtensionProperties` で拡張機能が**サポート**されているかどうかを確認することができます。
+アプリケーションは、まずlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-extensions[物理デバイスにクエリ]し、`vkEnumerateInstanceExtensionProperties` または `vkEnumerateDeviceExtensionProperties` で拡張機能が**サポート**されているかどうかを確認することができます。
 
 [source,cpp]
 ----
@@ -77,7 +77,7 @@ image::../../../chapters/images/enabling_extensions_8bit.png[enabling_extensions
 
 == 昇格プロセス
 
-Vulkan のマイナーバージョンがリリースされると、仕様書で定義されているように、いくつかの拡張機能がlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[昇格されます]。昇格の目的は、Vulkan ワーキンググループが広くサポートされていると判断した拡張機能を、Vulkan のコア仕様に組み込むことです。Vulkan のバージョンに関する詳細は、xref:{chapters}versions.adoc#versions[バージョン]の章を参照してください。
+Vulkan のマイナーバージョンがリリースされると、仕様書で定義されているように、いくつかの拡張機能がlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[昇格されます]。昇格の目的は、Vulkan ワーキンググループが広くサポートされていると判断した拡張機能を、Vulkan のコア仕様に組み込むことです。Vulkan のバージョンに関する詳細は、xref:{chapters}versions.adoc#versions[バージョン]の章を参照してください。
 
 たとえば、他のほとんどの拡張機能に使用されている `VK_KHR_get_physical_device_properties2` のようなものがあります。Vulkan 1.0では、アプリケーションは `vkGetPhysicalDeviceFeatures2KHR` のような関数を呼び出す前に、`VK_KHR_get_physical_device_properties2` の対応をクエリする必要があります。Vulkan 1.1からは、`vkGetPhysicalDeviceFeatures2` 関数の対応が保証されています。
 
@@ -85,9 +85,9 @@ Vulkan のマイナーバージョンがリリースされると、仕様書で�
 
 === 昇格による挙動変更
 
-昇格される**一部の**拡張機能には、微妙な違いがあることが重要です。仕様書では、昇格には拡張機能の「Feature advertisement/enablement」のような小さな変更が含まれることがあるとlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[説明されています]。この微妙な違いを説明するには、`VK_KHR_8bit_storage` をユースケースとして使用することができます。
+昇格される**一部の**拡張機能には、微妙な違いがあることが重要です。仕様書では、昇格には拡張機能の「Feature advertisement/enablement」のような小さな変更が含まれることがあるとlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[説明されています]。この微妙な違いを説明するには、`VK_KHR_8bit_storage` をユースケースとして使用することができます。
 
-Vulkan 仕様には、Vulkan 1.2の `VK_KHR_8bit_storage` のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#_differences_relative_to_vk_khr_8bit_storage[変更点]が以下のように記載されています。
+Vulkan 仕様には、Vulkan 1.2の `VK_KHR_8bit_storage` のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#_differences_relative_to_vk_khr_8bit_storage[変更点]が以下のように記載されています。
 
 ____
 VK_KHR_8bit_storage 拡張機能がサポートされていない場合、シェーダモジュールにおける SPIR-V StorageBuffer8BitAccess 機能の対応はオプションとなります。
@@ -98,4 +98,4 @@ ____
   * `vkEnumerateDeviceExtensionProperties` で `VK_KHR_8bit_storage` が見つかった場合、`storageBuffer8BitAccess` 機能がサポートされていることが**保証**されます。
   * `vkEnumerateDeviceExtensionProperties` で `VK_KHR_8bit_storage` が**見つからない**場合は、`storageBuffer8BitAccess` 機能が**サポートされているかもしれず** 、`VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess` をクエリすることで確認できます。
 
-昇格された拡張機能のすべての機能変更のリストは、仕様書のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#versions[バージョン付録]に記載されています。
+昇格された拡張機能のすべての機能変更のリストは、仕様書のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#versions[バージョン付録]に記載されています。

--- a/lang/jp/chapters/enabling_features.adoc
+++ b/lang/jp/chapters/enabling_features.adoc
@@ -13,17 +13,17 @@ ifndef::chapters[:chapters:]
 Vulkan のすべての機能は、3つのセクションに分類されます。
 
   1. コア1.0機能
-  ** Vulkan 1.0の初期リリースから利用可能な機能をまとめたものです。機能のリストは、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceFeatures[VkPhysicalDeviceFeatures]に記載されています。
+  ** Vulkan 1.0の初期リリースから利用可能な機能をまとめたものです。機能のリストは、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceFeatures[VkPhysicalDeviceFeatures]に記載されています。
   2. 将来のコアバージョンの機能
   ** Vulkan 1.1以上では、いくつかの新機能が Vulkan のコアバージョンに追加されました。`VkPhysicalDeviceFeatures` のサイズの後方互換性を保つために、機能のグループを保持するための新しい構造体が作成されました。
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceVulkan11Features[VkPhysicalDeviceVulkan11Features]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceVulkan12Features[VkPhysicalDeviceVulkan12Features]
+  ** link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceVulkan11Features[VkPhysicalDeviceVulkan11Features]
+  ** link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceVulkan12Features[VkPhysicalDeviceVulkan12Features]
   3. 拡張機能の機能
   ** 拡張機能には、その拡張機能のある側面を有効にするための機能が含まれていることがあります。これらはすべて `VkPhysicalDevice[ExtensionName]Features` とラベル付けされているので、簡単に見つけることができます。
 
 == 機能を有効にするには
 
-すべての機能は、`VkDevice` 作成時に link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkDeviceCreateInfo[VkDeviceCreateInfo] 構造体内で有効にする必要があります。
+すべての機能は、`VkDevice` 作成時に link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkDeviceCreateInfo[VkDeviceCreateInfo] 構造体内で有効にする必要があります。
 
 [NOTE]
 ====

--- a/lang/jp/chapters/extensions/VK_KHR_shader_subgroup_uniform_control_flow.adoc
+++ b/lang/jp/chapters/extensions/VK_KHR_shader_subgroup_uniform_control_flow.adoc
@@ -8,7 +8,7 @@ ifndef::chapters[:chapters: ../]
 
 == 概要
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_subgroup_uniform_control_flow.html[VK_KHR_shader_subgroup_uniform_control_flow] は、シェーダ内の呼び出しの再収束をより強く保証するものです。この拡張機能に対応している場合、シェーダはより強力な保証を提供する新しい属性を含むように修正できます（link:https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_subgroup_uniform_control_flow.txt[GL_EXT_subgroup_uniform_control_flow] を参照）。この属性は、サブグループ操作をサポートするシェーダステージにのみ適用可能です（`VkPhysicalDeviceSubgroupProperties::supportedStages` と
+link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_shader_subgroup_uniform_control_flow.html[VK_KHR_shader_subgroup_uniform_control_flow] は、シェーダ内の呼び出しの再収束をより強く保証するものです。この拡張機能に対応している場合、シェーダはより強力な保証を提供する新しい属性を含むように修正できます（link:https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_subgroup_uniform_control_flow.txt[GL_EXT_subgroup_uniform_control_flow] を参照）。この属性は、サブグループ操作をサポートするシェーダステージにのみ適用可能です（`VkPhysicalDeviceSubgroupProperties::supportedStages` と
 `VkPhysicalDeviceVulkan11Properties::subgroupSupportedStages` を確認してください）。
 
 この保証が強化されたことにより、SPIR-V 仕様のユニフォーム制御フロールールが、個々のサブグループにも適用されるようになりました。これらのルールの最も重要な部分は、すべての呼び出しがヘッダブロックへのエントリ時に収束した場合、マージブロックでの再収束を要求することです。これは、シェーダの作者によって暗黙のうちに信頼されていることもありますが、実際にはコア Vulkan 仕様によって保証されていません。

--- a/lang/jp/chapters/extensions/cleanup.adoc
+++ b/lang/jp/chapters/extensions/cleanup.adoc
@@ -20,7 +20,7 @@ ifndef::chapters[:chapters: ../]
 Vulkan 1.2でコアに昇格
 ====
 
-この拡張機能は、各実装に関するクエリに、より多くの情報を追加します。link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkDriverId[VkDriverId] は、その実装の登録ベンダーの ID になります。link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] は、実装が合格した Vulkan Conformance Test Suite のバージョンを表示します。
+この拡張機能は、各実装に関するクエリに、より多くの情報を追加します。link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkDriverId[VkDriverId] は、その実装の登録ベンダーの ID になります。link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] は、実装が合格した Vulkan Conformance Test Suite のバージョンを表示します。
 
 [[VK_EXT_host_query_reset]]
 == VK_EXT_host_query_reset
@@ -128,12 +128,12 @@ Vulkan 1.3でコアに昇格
 
 現在、6つのメンテナンス拡張機能があり、最初の3つは Vulkan 1.1にコアとしてバンドルされています。各拡張機能の詳細は、拡張機能の付録ページに記載されています。
 
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance1[VK_KHR_maintenance1] - Vulkan 1.1コア
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance2[VK_KHR_maintenance2] - Vulkan 1.1コア
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance3[VK_KHR_maintenance3] - Vulkan 1.1コア
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance4[VK_KHR_maintenance4] - Vulkan 1.3コア
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance5[VK_KHR_maintenance5]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance6[VK_KHR_maintenance6]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance1[VK_KHR_maintenance1] - Vulkan 1.1コア
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance2[VK_KHR_maintenance2] - Vulkan 1.1コア
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance3[VK_KHR_maintenance3] - Vulkan 1.1コア
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance4[VK_KHR_maintenance4] - Vulkan 1.3コア
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance5[VK_KHR_maintenance5]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance6[VK_KHR_maintenance6]
 
 [[pnext-expansions]]
 == pNext 拡張機能

--- a/lang/jp/chapters/extensions/ray_tracing.adoc
+++ b/lang/jp/chapters/extensions/ray_tracing.adoc
@@ -8,11 +8,11 @@ ifndef::chapters[:chapters: ../]
 
 相互に関連する5つの拡張機能により、Vulkan API においてレイトレーシングがサポートされています。
 
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_acceleration_structure.html[VK_KHR_acceleration_structure]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_ray_tracing_pipeline.html[VK_KHR_ray_tracing_pipeline]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_ray_query.html[VK_KHR_ray_query]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_pipeline_library.html[VK_KHR_pipeline_library]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_deferred_host_operations.html[VK_KHR_deferred_host_operations]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_acceleration_structure.html[VK_KHR_acceleration_structure]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_ray_tracing_pipeline.html[VK_KHR_ray_tracing_pipeline]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_ray_query.html[VK_KHR_ray_query]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_pipeline_library.html[VK_KHR_pipeline_library]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_deferred_host_operations.html[VK_KHR_deferred_host_operations]
 
 また、SPIR-V や GLSL の拡張機能を追加することで、シェーダに必要なプログラマブルな機能を実現しています。
 

--- a/lang/jp/chapters/extensions/shader_features.adoc
+++ b/lang/jp/chapters/extensions/shader_features.adoc
@@ -170,7 +170,7 @@ Vulkan 1.2でコアに昇格
 link:https://www.khronos.org/blog/comparing-the-vulkan-spir-v-memory-model-to-cs/[Comparing the Vulkan SPIR-V memory model to C's]
 ====
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#memory-model[Vulkan Memory Model] は、複数のシェーダ呼び出しによる同じメモリロケーションへのメモリアクセスを同期させる方法を公式に定義しています。この拡張機能では、実装がその対応を示すためのブール値を公開しています。これは、Vulkan/SPIR-V をターゲットにした多くの製品では、アプリケーションによって最適化されたメモリ転送操作が実装間で壊れないようにするために重要です。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#memory-model[Vulkan Memory Model] は、複数のシェーダ呼び出しによる同じメモリロケーションへのメモリアクセスを同期させる方法を公式に定義しています。この拡張機能では、実装がその対応を示すためのブール値を公開しています。これは、Vulkan/SPIR-V をターゲットにした多くの製品では、アプリケーションによって最適化されたメモリ転送操作が実装間で壊れないようにするために重要です。
 
 [[VK_EXT_shader_viewport_index_layer]]
 == VK_EXT_shader_viewport_index_layer

--- a/lang/jp/chapters/formats.adoc
+++ b/lang/jp/chapters/formats.adoc
@@ -6,20 +6,20 @@ ifndef::chapters[:chapters:]
 [[formats]]
 = フォーマット
 
-Vulkan のフォーマットは、メモリのレイアウトを記述するために使用されます。この章では、Vulkan のフォーマットのバリエーションに関する概要と、それらを使用する方法に関する情報を提供します。詳細は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#formats[Vulkan Spec フォーマット章] と link:https://www.khronos.org/registry/DataFormat/specs/1.3/dataformat.1.3.html[Khronos Data Format Specification] の両方に明記されています。
+Vulkan のフォーマットは、メモリのレイアウトを記述するために使用されます。この章では、Vulkan のフォーマットのバリエーションに関する概要と、それらを使用する方法に関する情報を提供します。詳細は、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#formats[Vulkan Spec フォーマット章] と link:https://www.khronos.org/registry/DataFormat/specs/1.3/dataformat.1.3.html[Khronos Data Format Specification] の両方に明記されています。
 
-`VkFormat` の最も一般的な使用例は、`VkImage` を作成する場合です。`VkFormat` はうまく定義されているため、`VkBufferView` 、xref:{chapters}vertex_input_data_processing.adoc#input-attribute-format[頂点入力属性]、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-image-formats[SPIR-V イメージフォーマットのマッピング]、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html[ボトムレベル高速化構造での三角形ジオメトリ作成]などのためのメモリレイアウトを記述する場合にも使用されます。
+`VkFormat` の最も一般的な使用例は、`VkImage` を作成する場合です。`VkFormat` はうまく定義されているため、`VkBufferView` 、xref:{chapters}vertex_input_data_processing.adoc#input-attribute-format[頂点入力属性]、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#spirvenv-image-formats[SPIR-V イメージフォーマットのマッピング]、link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html[ボトムレベル高速化構造での三角形ジオメトリ作成]などのためのメモリレイアウトを記述する場合にも使用されます。
 
 [[feature-support]]
 == 機能の対応
 
-「フォーマットの対応」は、フォーマットごとに単一のバイナリ値ではなく、各フォーマットが link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] のセットを持ち、それぞれがそのフォーマットでサポートされている機能を記述していることが重要です。
+「フォーマットの対応」は、フォーマットごとに単一のバイナリ値ではなく、各フォーマットが link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] のセットを持ち、それぞれがそのフォーマットでサポートされている機能を記述していることが重要です。
 
-サポートされるフォーマットは実装によって異なる可能性がありますが、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#features-required-format-support[フォーマット機能の最小セットは保証]されています。アプリケーションは、サポートされているフォーマットのプロパティをlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#formats-properties[クエリ]することができます。
+サポートされるフォーマットは実装によって異なる可能性がありますが、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-required-format-support[フォーマット機能の最小セットは保証]されています。アプリケーションは、サポートされているフォーマットのプロパティをlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#formats-properties[クエリ]することができます。
 
 [NOTE]
 ====
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_get_physical_device_properties2.html[VK_KHR_get_physical_device_properties2] と link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_format_feature_flags2.html[VK_KHR_format_feature_flags2] は共に、フォーマット機能をクエリするための別の方法を公開します。
+link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_get_physical_device_properties2.html[VK_KHR_get_physical_device_properties2] と link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_format_feature_flags2.html[VK_KHR_format_feature_flags2] は共に、フォーマット機能をクエリするための別の方法を公開します。
 ====
 
 === フォーマット機能をクエリする例
@@ -74,7 +74,7 @@ if ((formatProperties3.linearTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_
 
 == フォーマットのバリエーション
 
-フォーマットには多くのバリエーションがあり、ほとんどは link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#_identification_of_formats[フォーマットの名前]でグループ化されています。イメージを扱う場合、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageAspectFlagBits.html[VkImageAspectFlagBits] 値は、クリアやコピーなどの操作のために、データのどの部分にアクセスするかを表すために使用されます。
+フォーマットには多くのバリエーションがあり、ほとんどは link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#_identification_of_formats[フォーマットの名前]でグループ化されています。イメージを扱う場合、link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkImageAspectFlagBits.html[VkImageAspectFlagBits] 値は、クリアやコピーなどの操作のために、データのどの部分にアクセスするかを表すために使用されます。
 
 === 色
 
@@ -82,41 +82,41 @@ if ((formatProperties3.linearTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_
 
 === 深度とステンシル
 
-`D` または `S` 成分を持つフォーマットです。これらのフォーマットはlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#formats-depth-stencil[不透明とみなされ]、深度/ステンシルイメージとのlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkBufferImageCopy[コピー]に関して特別なルールがあります。
+`D` または `S` 成分を持つフォーマットです。これらのフォーマットはlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#formats-depth-stencil[不透明とみなされ]、深度/ステンシルイメージとのlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkBufferImageCopy[コピー]に関して特別なルールがあります。
 
 いくつかのフォーマットは、深度成分とステンシル成分の両方を持ち、 `VK_IMAGE_ASPECT_DEPTH_BIT` と `VK_IMAGE_ASPECT_STENCIL_BIT` で別々にアクセスできます。
 
 [NOTE]
 ====
-Vulkan 1.2 で昇格した link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_separate_depth_stencil_layouts.html[VK_KHR_separate_depth_stencil_layouts] と link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_separate_stencil_usage.html[VK_EXT_separate_stencil_usage] を使用すると、深度とステンシル成分間でより細かく制御できるようになります。
+Vulkan 1.2 で昇格した link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_separate_depth_stencil_layouts.html[VK_KHR_separate_depth_stencil_layouts] と link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_separate_stencil_usage.html[VK_EXT_separate_stencil_usage] を使用すると、深度とステンシル成分間でより細かく制御できるようになります。
 ====
 
 深度フォーマットについての詳しい情報は、xref:{chapters}depth.adoc#depth-formats[深度の章]にあります。
 
 === 圧縮
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#compressed_image_formats[圧縮イメージ]は、1つの領域内に複数の画素を相互依存的にエンコードして表現する形式です。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#compressed_image_formats[圧縮イメージ]は、1つの領域内に複数の画素を相互依存的にエンコードして表現する形式です。
 
 
 .Vulkan 圧縮イメージフォーマット
 [options="header"]
 |===
 |フォーマット|有効化方法
-|link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-bc[BC (Block-Compressed)] |`VkPhysicalDeviceFeatures::textureCompressionBC`
-|link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-etc2[ETC2 and EAC] |`VkPhysicalDeviceFeatures::textureCompressionETC2`
-|link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-astc[ASTC LDR] |`VkPhysicalDeviceFeatures::textureCompressionASTC_LDR`
-|link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-astc[ASTC HDR] |link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_texture_compression_astc_hdr.html[VK_EXT_texture_compression_astc_hdr]
-|link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-pvrtc[PVRTC] | link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_IMG_format_pvrtc.html[VK_IMG_format_pvrtc]
+|link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-bc[BC (Block-Compressed)] |`VkPhysicalDeviceFeatures::textureCompressionBC`
+|link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-etc2[ETC2 and EAC] |`VkPhysicalDeviceFeatures::textureCompressionETC2`
+|link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-astc[ASTC LDR] |`VkPhysicalDeviceFeatures::textureCompressionASTC_LDR`
+|link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-astc[ASTC HDR] |link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_texture_compression_astc_hdr.html[VK_EXT_texture_compression_astc_hdr]
+|link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-pvrtc[PVRTC] | link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_IMG_format_pvrtc.html[VK_IMG_format_pvrtc]
 |===
 
 === 平面
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_sampler_ycbcr_conversion.html[VK_KHR_sampler_ycbcr_conversion] と link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_ycbcr_2plane_444_formats.html[VK_EXT_ycbcr_2plane_444_formats] は xref:{chapters}VK_KHR_sampler_ycbcr_conversion.adoc#multi-planar-formats[multi-planar フォーマット] を Vulkan に追加しました。
+link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_sampler_ycbcr_conversion.html[VK_KHR_sampler_ycbcr_conversion] と link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_ycbcr_2plane_444_formats.html[VK_EXT_ycbcr_2plane_444_formats] は xref:{chapters}VK_KHR_sampler_ycbcr_conversion.adoc#multi-planar-formats[multi-planar フォーマット] を Vulkan に追加しました。
 `VK_IMAGE_ASPECT_PLANE_0_BIT`、`VK_IMAGE_ASPECT_PLANE_1_BIT`、`VK_IMAGE_ASPECT_PLANE_2_BIT` で平面に個別にアクセスできます。
 
 === パック
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#formats-packed[パックされたフォーマット]は、アドレスアライメントを目的としたものです。例として、`VK_FORMAT_A8B8G8R8_UNORM_PACK32` と `VK_FORMAT_R8G8B8A8_UNORM` は非常に似ていますが、仕様の link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex-input-extraction[Vertex Input Extraction セクション]の数式を使用すると、以下のようになります。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#formats-packed[パックされたフォーマット]は、アドレスアライメントを目的としたものです。例として、`VK_FORMAT_A8B8G8R8_UNORM_PACK32` と `VK_FORMAT_R8G8B8A8_UNORM` は非常に似ていますが、仕様の link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fxvertex-input-extraction[Vertex Input Extraction セクション]の数式を使用すると、以下のようになります。
 
 ____
 attribAddress = bufferBindingAddress + vertexOffset + attribDesc.offset;
@@ -126,4 +126,4 @@ ____
 
 === 外部
 
-現在、`VK_ANDROID_external_memory_android_hardware_buffer` 拡張機能でのみサポートされています。この拡張機能を使うと、Android アプリケーションが実装で定義された外部フォーマットをインポートし、 xref:{chapters}VK_KHR_sampler_ycbcr_conversion.adoc[VkSamplerYcbcrConversion] で使用できるようになります。これらの外部フォーマットで許可されるものには多くの制限があり、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#memory-external-android-hardware-buffer-external-formats[仕様に記載]されています。
+現在、`VK_ANDROID_external_memory_android_hardware_buffer` 拡張機能でのみサポートされています。この拡張機能を使うと、Android アプリケーションが実装で定義された外部フォーマットをインポートし、 xref:{chapters}VK_KHR_sampler_ycbcr_conversion.adoc[VkSamplerYcbcrConversion] で使用できるようになります。これらの外部フォーマットで許可されるものには多くの制限があり、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#memory-external-android-hardware-buffer-external-formats[仕様に記載]されています。

--- a/lang/jp/chapters/layers.adoc
+++ b/lang/jp/chapters/layers.adoc
@@ -6,7 +6,7 @@ ifndef::chapters[:chapters:]
 [[layers]]
 = レイヤ
 
-レイヤは、Vulkan システムを補強するオプション要素です。レイヤは、アプリケーションからハードウェアに至るまで、既存の Vulkan 関数をインターセプトし、評価し、修正することができます。レイヤのプロパティは、アプリケーションから link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#vkEnumerateInstanceLayerProperties[vkEnumerateInstanceLayerProperties] でクエリできます。
+レイヤは、Vulkan システムを補強するオプション要素です。レイヤは、アプリケーションからハードウェアに至るまで、既存の Vulkan 関数をインターセプトし、評価し、修正することができます。レイヤのプロパティは、アプリケーションから link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkEnumerateInstanceLayerProperties[vkEnumerateInstanceLayerProperties] でクエリできます。
 
 == レイヤの使い方
 
@@ -20,7 +20,7 @@ Windows、Linux、macOS の開発者は、Vulkan Configurator（vkconfig）を�
 
 == デバイスレイヤの非推奨化
 
-かつてはインスタンスレイヤとデバイスレイヤの両方がありましたが、デバイスレイヤは Vulkan の初期段階でlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation[非推奨]となっているため、避けてください。
+かつてはインスタンスレイヤとデバイスレイヤの両方がありましたが、デバイスレイヤは Vulkan の初期段階でlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation[非推奨]となっているため、避けてください。
 
 == レイヤの作成
 

--- a/lang/jp/chapters/mapping_data_to_shaders.adoc
+++ b/lang/jp/chapters/mapping_data_to_shaders.adoc
@@ -12,7 +12,7 @@ ifndef::chapters[:chapters:]
 全ての SPIR-V アセンブリは glslangValidator で生成されています。
 ====
 
-この章では、データをマッピングするための link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces[Vulkan と SPIR-V のインターフェイス]の方法について説明します。`vkAllocateMemory` から割り当てられた `VkDeviceMemory` オブジェクトを使って、Vulkan からのデータを SPIR-V シェーダが正しく利用できるように適切にマッピングするのは、アプリケーションの責任です。
+この章では、データをマッピングするための link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces[Vulkan と SPIR-V のインターフェイス]の方法について説明します。`vkAllocateMemory` から割り当てられた `VkDeviceMemory` オブジェクトを使って、Vulkan からのデータを SPIR-V シェーダが正しく利用できるように適切にマッピングするのは、アプリケーションの責任です。
 
 コア Vulkan では、Vulkan アプリケーションのデータを SPIR-V とのインターフェイスにマッピングするための基本的な方法が5つあります。
 
@@ -101,11 +101,11 @@ vkEndCommandBuffer();
 [[descriptors]]
 == ディスクリプタ
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets[リソースディスクリプタ]は、ユニフォームバッファ、ストレージバッファ、サンプラなどのデータを Vulkan の任意のシェーダステージにマッピングするためのコアとなる方法です。概念的には、ディスプリプタはシェーダが使用できるメモリへのポインタと考えられます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets[リソースディスクリプタ]は、ユニフォームバッファ、ストレージバッファ、サンプラなどのデータを Vulkan の任意のシェーダステージにマッピングするためのコアとなる方法です。概念的には、ディスプリプタはシェーダが使用できるメモリへのポインタと考えられます。
 
-Vulkan にはさまざまなlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkDescriptorType[ディスクリプタタイプ]があり、それぞれが何を許可しているのかlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-types[詳細に説明されています]。
+Vulkan にはさまざまなlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkDescriptorType[ディスクリプタタイプ]があり、それぞれが何を許可しているのかlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-types[詳細に説明されています]。
 
-ディスクリプタは、シェーダにバインドされるlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-sets[ディスクリプタセット]にまとめられます。ディスクリプタセットの中に1つのディスクリプタしかない場合でも、シェーダにバインドする際には `VkDescriptorSet` 全体が使用されます。
+ディスクリプタは、シェーダにバインドされるlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-sets[ディスクリプタセット]にまとめられます。ディスクリプタセットの中に1つのディスクリプタしかない場合でも、シェーダにバインドする際には `VkDescriptorSet` 全体が使用されます。
 
 === 例
 
@@ -181,9 +181,9 @@ image::../../../chapters/images/mapping_data_to_shaders_descriptor_2.png[mapping
 [[descriptor-types]]
 === ディスクリプタタイプ
 
-Vulkan Spec にはlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-storage-class-correspondence[シェーダリソースとストレージクラスの対応表]があり、SPIR-V で各ディスクリプタタイプをどのようにマッピングするかが記載されています。
+Vulkan Spec にはlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-storage-class-correspondence[シェーダリソースとストレージクラスの対応表]があり、SPIR-V で各ディスクリプタタイプをどのようにマッピングするかが記載されています。
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-types[ディスクリプタタイプ]のそれぞれに GLSL と SPIR-V をマッピングした場合の例を以下に示します。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-types[ディスクリプタタイプ]のそれぞれに GLSL と SPIR-V をマッピングした場合の例を以下に示します。
 
 GLSL については、link:https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.pdf[GLSL Spec - 12.2.4. Vulkan Only: Samplers, Images, Textures, and Buffers] から詳細をご覧いただけます。
 
@@ -459,7 +459,7 @@ OpDecorate %inputAttachment InputAttachmentIndex 0
 [[specialization-constants]]
 == 特殊化定数
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-specialization-constants[特殊化定数]とは、`VkPipeline` の作成時に SPIR-V の定数値を指定できる仕組みです。これは、高レベルのシェーディング言語（GLSL、HLSLなど）でプリプロセッサマクロを行うという考えを置き換えるもので、強力です。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipelines-specialization-constants[特殊化定数]とは、`VkPipeline` の作成時に SPIR-V の定数値を指定できる仕組みです。これは、高レベルのシェーディング言語（GLSL、HLSLなど）でプリプロセッサマクロを行うという考えを置き換えるもので、強力です。
 
 === 例
 
@@ -561,13 +561,13 @@ vkCreateGraphicsPipelines(&pipelineInfo);
 [[physical-storage-buffer]]
 == 物理ストレージバッファ
 
-Vulkan 1.2で採用された link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address] 拡張により、「シェーダ内のポインタ」を持つ機能が追加されました。SPIR-V の `PhysicalStorageBuffer` ストレージクラスを使って、アプリケーションは `vkGetBufferDeviceAddress` を呼び出し、メモリへの `VkDeviceAddress` を返すことができます。
+Vulkan 1.2で採用された link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address] 拡張により、「シェーダ内のポインタ」を持つ機能が追加されました。SPIR-V の `PhysicalStorageBuffer` ストレージクラスを使って、アプリケーションは `vkGetBufferDeviceAddress` を呼び出し、メモリへの `VkDeviceAddress` を返すことができます。
 
 これはデータをシェーダにマッピングする方法ではありますが、シェーダとのインターフェイスになるわけではありません。たとえば、アプリケーションがユニフォームバッファでこれを使用したい場合、 `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` と `VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT` の両方を持つ `VkBuffer` を作成する必要があります。この例では、Vulkan はシェーダとのインターフェイスにディスクリプタを使用しますが、その後、物理ストレージバッファを使用して値を更新することができます。
 
 == 制限
 
-Vulkan には、一度にバインドできるデータ量にlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#limits[制限]があることが重要です。
+Vulkan には、一度にバインドできるデータ量にlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#limits[制限]があることが重要です。
 
   * 入力属性
   ** `maxVertexInputAttributes`

--- a/lang/jp/chapters/memory_allocation.adoc
+++ b/lang/jp/chapters/memory_allocation.adoc
@@ -14,13 +14,13 @@ Vulkan のメモリ管理に関する2つの Khronos のプレゼンテーショ
 
 == サブ割り当て
 
-サブ割り当ては Vulkan では最も良いアプローチです。また、アプリケーションが同時に使用できるアクティブな割り当て数である link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#limits-maxMemoryAllocationCount[maxMemoryAllocationCount] が存在することも重要です。OS やドライバレベルでのメモリ割り当てと解放は非常に遅くなる可能性があり、これがサブ割り当てのもう一つの理由です。Vulkan アプリは大きな割り当てを作成し、それを自分で管理することを目指すべきです。
+サブ割り当ては Vulkan では最も良いアプローチです。また、アプリケーションが同時に使用できるアクティブな割り当て数である link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#limits-maxMemoryAllocationCount[maxMemoryAllocationCount] が存在することも重要です。OS やドライバレベルでのメモリ割り当てと解放は非常に遅くなる可能性があり、これがサブ割り当てのもう一つの理由です。Vulkan アプリは大きな割り当てを作成し、それを自分で管理することを目指すべきです。
 
 image::../../../chapters/images/memory_allocation_sub_allocation.png[memory_allocation_sub_allocation.png]
 
 == 転送
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#VkPhysicalDeviceType[VkPhysicalDeviceType] では、主にディスクリートと統合型（UMA（ユニファイド・メモリ・アーキテクチャ）とも呼ばれる）の2タイプの GPU を示しています。この2つの違いを理解することは、パフォーマンスにとって重要です。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceType[VkPhysicalDeviceType] では、主にディスクリートと統合型（UMA（ユニファイド・メモリ・アーキテクチャ）とも呼ばれる）の2タイプの GPU を示しています。この2つの違いを理解することは、パフォーマンスにとって重要です。
 
 ディスクリートのグラフィックスカードは、デバイス上に専用のメモリを搭載しています。データはバス（PCIe など）を介して転送されますが、このバスは通常、データ転送の物理的な速度制限のためにボトルネックとなります。一部の物理デバイスは、データ転送専用のキューを可能にする `VK_QUEUE_TRANSFER_BIT` を使用してキューを示します。一般的には、ホストデータをコピーするためのステージングバッファを作成してから、コマンドバッファを経由してデバイスのローカルメモリにコピーします。
 

--- a/lang/jp/chapters/pipeline_cache.adoc
+++ b/lang/jp/chapters/pipeline_cache.adoc
@@ -6,7 +6,7 @@ ifndef::chapters[:chapters:]
 [[pipeline-cache]]
 = パイプラインキャッシュ
 
-パイプラインキャッシングとは、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#VkPipelineCache[VkPipelineCache] オブジェクトを使って、すでに作成されたパイプラインを再利用する技術です。パイプラインの作成には多少のコストがかかります。たとえば、作成時にシェーダをコンパイルする必要があります。パイプラインキャッシュの大きな利点は、パイプラインの状態をファイルに保存して、アプリケーションの実行間に使用することができるので、作成時のコストを取り除くことができます。SIGGRAPH 2016のパイプラインキャッシュに関する Khronos のlink:https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/3D-BOF-SIGGRAPH_Jul16.pdf[プレゼンテーション]（link:https://www.youtube.com/watch?v=owuJRPKIUAg&t=1045s[動画]）がスライド140からあります。
+パイプラインキャッシングとは、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkPipelineCache[VkPipelineCache] オブジェクトを使って、すでに作成されたパイプラインを再利用する技術です。パイプラインの作成には多少のコストがかかります。たとえば、作成時にシェーダをコンパイルする必要があります。パイプラインキャッシュの大きな利点は、パイプラインの状態をファイルに保存して、アプリケーションの実行間に使用することができるので、作成時のコストを取り除くことができます。SIGGRAPH 2016のパイプラインキャッシュに関する Khronos のlink:https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/3D-BOF-SIGGRAPH_Jul16.pdf[プレゼンテーション]（link:https://www.youtube.com/watch?v=owuJRPKIUAg&t=1045s[動画]）がスライド140からあります。
 
 image::../../../chapters/images/pipeline_cache_cache.png[pipeline_cache_cache.png]
 

--- a/lang/jp/chapters/platforms.adoc
+++ b/lang/jp/chapters/platforms.adoc
@@ -53,4 +53,4 @@ Vulkan は、Windows 7、Windows 8、および Windows 10 でサポートされ�
 
 == Others
 
-組込みシステムの中には Vulkan をサポートしているものもあり、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#display[ディスプレイに直接]表示できます。
+組込みシステムの中には Vulkan をサポートしているものもあり、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#display[ディスプレイに直接]表示できます。

--- a/lang/jp/chapters/pnext_and_stype.adoc
+++ b/lang/jp/chapters/pnext_and_stype.adoc
@@ -16,7 +16,7 @@ Vulkan を初めて使う方は、Vulkan Spec のあちこちにある `pNext` �
 
 == 2つの基本構造体
 
-Vulkan API は、`VkBaseInStructure` と `VkBaseOutStructure` というlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#fundamentals-validusage-pNext[2つの基本構造体を提供]し、構造体ポインタチェーンを辿るために使用されます。
+Vulkan API は、`VkBaseInStructure` と `VkBaseOutStructure` というlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fundamentals-validusage-pNext[2つの基本構造体を提供]し、構造体ポインタチェーンを辿るために使用されます。
 
 `VkBaseInStructure` の `In` は、`pNext` が `const *` であることを意味し、受け取ったローダ、レイヤ、ドライバでは読み取り専用となります。`VkBaseOutStructure` の `Out` は、`pNext` がアプリケーションにデータを返すために使用されることを指します。
 
@@ -89,7 +89,7 @@ void vkGetValue(VkA* pA) {
                 LOG("Unsupported sType %d", next->sType);
         }
 
-        // これが動くのは、連鎖可能な Vulkan 構造体の最初の2つの値が 
+        // これが動くのは、連鎖可能な Vulkan 構造体の最初の2つの値が
         // "sType" と "pNext" であり、pNext のオフセットが同じであるため
         next = reinterpret_cast<VkBaseOutStructure*>(next->pNext);
     }

--- a/lang/jp/chapters/portability_initiative.adoc
+++ b/lang/jp/chapters/portability_initiative.adoc
@@ -8,7 +8,7 @@ ifndef::chapters[:chapters:]
 
 [NOTE]
 ====
-現在、暫定的な link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_portability_subset.html[VK_KHR_portability_subset] 拡張機能が link:https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_beta.h[vulkan_beta.h] ヘッダで提供されています。詳細はlink:https://www.khronos.org/blog/fighting-fragmentation-vulkan-portability-extension-released-implementations-shipping[プレスリリース]を参照してください。
+現在、暫定的な link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_portability_subset.html[VK_KHR_portability_subset] 拡張機能が link:https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_beta.h[vulkan_beta.h] ヘッダで提供されています。詳細はlink:https://www.khronos.org/blog/fighting-fragmentation-vulkan-portability-extension-released-implementations-shipping[プレスリリース]を参照してください。
 ====
 
 link:https://www.vulkan.org/portability[Vulkan Portability Initiative] は、Khronos グループ内の取り組みで、現在 Vulkan のネイティブドライバが提供されていないプラットフォームを含む、すべての主要なプラットフォームでネイティブレベルのパフォーマンスで普遍的に利用できる Vulkan 機能のlink:https://github.com/KhronosGroup/Vulkan-Portability[サブセット]を定義し、発展させるためのリソースを開発しています。一言で言えば、Vulkan をネイティブにサポートしていないプラットフォーム（MacOSやiOSなど）でも、Vulkan を利用できるようにするためのイニシアチブです。

--- a/lang/jp/chapters/protected.adoc
+++ b/lang/jp/chapters/protected.adoc
@@ -11,7 +11,7 @@ ifndef::chapters[:chapters:]
 
 ほとんどの OS は、明示的に共有（たとえば xref:{chapters}extensions/external.adoc#external-memory[外部メモリ] を介して）されていない限り、あるアプリケーションが別のアプリケーションの GPU メモリにアクセスすることを許可しません。保護されたメモリの一般的な例は、DRM コンテンツを格納するためのものです。プロセスは、（イメージフィルタリング、再生コントロールやクローズドキャプションの合成などのために）変更を許可されるかもしれませんが、保護されていないメモリに抽出することはできません。データは暗号化されて送られ、ディスプレイ上のピクセルに届くまで暗号化されたままです。
 
-Vulkan Spec では、「保護されたデバイスメモリ」が実行することをlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#memory-protected-memory[詳しく説明しています]。以下では、保護されたメモリを使用して保護されたサブミットを適切に有効化するために必要なことを示します。
+Vulkan Spec では、「保護されたデバイスメモリ」が実行することをlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#memory-protected-memory[詳しく説明しています]。以下では、保護されたメモリを使用して保護されたサブミットを適切に有効化するために必要なことを示します。
 
 == 対応の確認
 
@@ -87,7 +87,7 @@ vkGetDeviceQueue2(deviceHandle, &info, &protectedQueue);
 
 保護されたスワップチェーンから `vkGetSwapchainImagesKHR` で取得したすべての `VkImage` は、`VK_IMAGE_CREATE_PROTECTED_BIT` で作成された場合と同じものになります。
 
-`VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` フラグが設定されている状態でスワップチェーンを作成できるかどうか不明な場合があります。link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_surface_protected_capabilities.html[VK_KHR_surface_protected_capabilities] 拡張機能は、これが不明な可能性があるプラットフォームで公開されています。
+`VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` フラグが設定されている状態でスワップチェーンを作成できるかどうか不明な場合があります。link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_surface_protected_capabilities.html[VK_KHR_surface_protected_capabilities] 拡張機能は、これが不明な可能性があるプラットフォームで公開されています。
 
 == 保護されたコマンドバッファ
 

--- a/lang/jp/chapters/push_constants.adoc
+++ b/lang/jp/chapters/push_constants.adoc
@@ -33,7 +33,7 @@ API 経由で値を書き込める小さなメモリ領域で、シェーダか�
 [[pc-shader-code]]
 === シェーダコード
 
-シェーダから見ると、プッシュ定数はユニフォームバッファと似ています。VulkanとSPIR-Vの間のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-pushconst[プッシュ定数インターフェース]は、Specに記載されています。
+シェーダから見ると、プッシュ定数はユニフォームバッファと似ています。VulkanとSPIR-Vの間のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-pushconst[プッシュ定数インターフェース]は、Specに記載されています。
 
 簡単な GLSLのフラグメントシェーダの例です (link:https://godbolt.org/z/93WaYd8dE[オンラインで試す]):
 
@@ -68,12 +68,12 @@ SPIR-Vの逆アセンブル:
 %access_chain   = OpAccessChain %pc_v4float_ptr %pc_var %int_0
 ----
 
-これは、`Block` 修飾を持つ `OpTypeStruct` タイプであるという link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-pushconst[Vulkan Spec]の記述に一致します。
+これは、`Block` 修飾を持つ `OpTypeStruct` タイプであるという link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-pushconst[Vulkan Spec]の記述に一致します。
 
 [[pc-pipeline-layout]]
 === パイプラインレイアウト
 
-`vkCreatePipelineLayout` の呼び出し時に、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineLayoutCreateInfo.html[VkPipelineLayoutCreateInfo]にlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPushConstantRange.html[プッシュ定数範囲]を設定する必要があります。
+`vkCreatePipelineLayout` の呼び出し時に、link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPipelineLayoutCreateInfo.html[VkPipelineLayoutCreateInfo]にlink:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPushConstantRange.html[プッシュ定数範囲]を設定する必要があります。
 
 上記のシェーダを使用した例:
 
@@ -100,7 +100,7 @@ vkCreatePipelineLayout(device, &create_info, NULL, &pipeline_layout);
 [[pc-updating]]
 === 記録時に更新する
 
-最後に、プッシュ定数の値は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdPushConstants.html[vkCmdPushConstants]を使用して更新する必要があります。
+最後に、プッシュ定数の値は、link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/vkCmdPushConstants.html[vkCmdPushConstants]を使用して更新する必要があります。
 
 [source,cpp]
 ----
@@ -159,14 +159,14 @@ image::../../../chapters/images/push_constant_offset.png[push_constant_offset]
 [[pc-pipeline-layout-compatibility]]
 == パイプラインレイアウトの互換性
 
-Vulkan Spec では、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-compatibility[プッシュ定数との互換]を次のように定義しています。
+Vulkan Spec では、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-compatibility[プッシュ定数との互換]を次のように定義しています。
 
 [NOTE]
 ====
 パイプラインレイアウトが同じプッシュ定数範囲で作成された場合
 ====
 
-つまり、バインドされた link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-bindpoint-commands[パイプラインコマンド]　（`vkCmdDraw`、`vkCmdDispatch` など）が呼ばれる直前の `vkCmdPushConstants` と `vkCmdBindPipeline`（適切な `VkPipelineBindPoint` 用）で使用された `VkPipelineLayout` は、**同じ** `VkPushConstantRange` を持っている必要があります。
+つまり、バインドされた link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipeline-bindpoint-commands[パイプラインコマンド]　（`vkCmdDraw`、`vkCmdDispatch` など）が呼ばれる直前の `vkCmdPushConstants` と `vkCmdBindPipeline`（適切な `VkPipelineBindPoint` 用）で使用された `VkPipelineLayout` は、**同じ** `VkPushConstantRange` を持っている必要があります。
 
 [[pc-lifetime]]
 == プッシュ定数の寿命

--- a/lang/jp/chapters/querying_extensions_features.adoc
+++ b/lang/jp/chapters/querying_extensions_features.adoc
@@ -39,17 +39,17 @@ Vulkan には、現在は存在しない新機能が望まれることが多々�
 詳しくはxref:{chapters}enabling_features.adoc#enabling-features[機能の有効化]の章をご覧ください。
 ====
 
-機能は、一部の実装でサポートされていない機能を表します。機能は、`VkDevice` の作成時にlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#vkGetPhysicalDeviceFeatures[クエリ]し、有効にすることができます。link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#features[すべての機能のリスト]に加えて、より新しい Vulkan バージョンや拡張機能の使用により、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-requirements[必須となる機能]があります。
+機能は、一部の実装でサポートされていない機能を表します。機能は、`VkDevice` の作成時にlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceFeatures[クエリ]し、有効にすることができます。link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features[すべての機能のリスト]に加えて、より新しい Vulkan バージョンや拡張機能の使用により、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-requirements[必須となる機能]があります。
 
 一般的な手法としては、拡張機能が `pNext` に渡すことのできる新しい構造体を公開することで、クエリ可能な機能を増やすことができます。
 
 == 制限
 
-制限とは、アプリケーションが注意しなければならない実装依存の最小値、最大値、その他のデバイス特性のことです。link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#limits[すべての制限のリスト]に加えて、いくつかの制限には Vulkan の実装で保証されるlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#limits-minmax[最小/最大の必要な値]があります。
+制限とは、アプリケーションが注意しなければならない実装依存の最小値、最大値、その他のデバイス特性のことです。link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#limits[すべての制限のリスト]に加えて、いくつかの制限には Vulkan の実装で保証されるlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#limits-minmax[最小/最大の必要な値]があります。
 
 == フォーマット
 
-Vulkan は多くの `VkFormat` を提供しています。それらは、さまざまな link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] ビットマスクを保持する複数の `VkFormatFlags` を持ち、クエリすることができます。
+Vulkan は多くの `VkFormat` を提供しています。それらは、さまざまな link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] ビットマスクを保持する複数の `VkFormatFlags` を持ち、クエリすることができます。
 
 詳しくは xref:{chapters}formats.adoc#feature-support [フォーマットの章] をご覧ください。
 

--- a/lang/jp/chapters/queues.adoc
+++ b/lang/jp/chapters/queues.adoc
@@ -31,12 +31,12 @@ ifndef::chapters[:chapters:]
 
 `VkQueue` がサポートできる操作にはさまざまな種類があります。「キューファミリ」とは、`VkQueueFamilyProperties` で示されているように、共通のプロパティを持ち、同じ機能をサポートする `VkQueue` のセットを表しています。
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkQueueFlagBits.html[VkQueueFlagBits] に記載されているキューの操作を以下に示します。
+link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkQueueFlagBits.html[VkQueueFlagBits] に記載されているキューの操作を以下に示します。
 
   * `VK_QUEUE_GRAPHICS_BIT` は `vkCmdDraw*` とグラフィックパイプラインのコマンドに使用されます。
   * `VK_QUEUE_COMPUTE_BIT` は `vkCmdDispatch*` や `vkCmdTraceRays*` といったコンピュートパイプライン関連のコマンドに使用されます。
   * `VK_QUEUE_TRANSFER_BIT` は全ての転送コマンドに使用されます。
-  ** 仕様書の link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineStageFlagBits.html[VK_PIPELINE_STAGE_TRANSFER_BIT] には「転送コマンド」が記載されています。
+  ** 仕様書の link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPipelineStageFlagBits.html[VK_PIPELINE_STAGE_TRANSFER_BIT] には「転送コマンド」が記載されています。
   ** `VK_QUEUE_TRANSFER_BIT` のみを持つキューファミリは、通常、link:https://en.wikipedia.org/wiki/Direct_memory_access[DMA] を使用して、ホストとディスクリート GPU 上のデバイスメモリ間で非同期にデータを転送するためのもので、独立したグラフィックス/コンピュート処理と同時に転送を行うことができます。
   ** `VK_QUEUE_GRAPHICS_BIT` および `VK_QUEUE_COMPUTE_BIT` は、常に `VK_QUEUE_TRANSFER_BIT` コマンドを暗黙的に受け入れることができます。
   * `VK_QUEUE_SPARSE_BINDING_BIT` は、xref:{chapters}sparse_resources.adoc#sparse-resources[スパースリソース（sparse resources）] を `vkQueueBindSparse` でメモリにバインドする際に使用されます。

--- a/lang/jp/chapters/robustness.adoc
+++ b/lang/jp/chapters/robustness.adoc
@@ -24,37 +24,37 @@ image::../../../chapters/images/robustness_flow.png[robustness_flow.png]
 
 == Vulkan がコアで提供するもの
 
-すべての Vulkan の実装は `robustBufferAccess` 機能をサポートする必要があります。仕様では、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess[何が境界を越えたとみなされるか]、またどのように処理されるべきかが説明されています。`robustBufferAccess` については、実装にある程度の柔軟性が与えられています。たとえば、`vec4(x,y,z,w)` へのアクセスで `w` の値が境界を越えた場合、仕様では `x`、`y`、`z` も境界を越えたとみなすかどうかを実装が決定できるようになっています。
+すべての Vulkan の実装は `robustBufferAccess` 機能をサポートする必要があります。仕様では、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess[何が境界を越えたとみなされるか]、またどのように処理されるべきかが説明されています。`robustBufferAccess` については、実装にある程度の柔軟性が与えられています。たとえば、`vec4(x,y,z,w)` へのアクセスで `w` の値が境界を越えた場合、仕様では `x`、`y`、`z` も境界を越えたとみなすかどうかを実装が決定できるようになっています。
 
-`VK_EXT_descriptor_indexing`（Vulkan 1.2のコア）にあるバインド機能の後の更新を扱う場合は、実装が `robustBufferAccess` とディスクリプタのバインド後の更新機能の両方をサポートするかどうかを示す link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#limits-robustBufferAccessUpdateAfterBind[robustBufferAccessUpdateAfterBind] を確認することが重要です。
+`VK_EXT_descriptor_indexing`（Vulkan 1.2のコア）にあるバインド機能の後の更新を扱う場合は、実装が `robustBufferAccess` とディスクリプタのバインド後の更新機能の両方をサポートするかどうかを示す link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#limits-robustBufferAccessUpdateAfterBind[robustBufferAccessUpdateAfterBind] を確認することが重要です。
 
-`robustBufferAccess` 機能は、バッファのみを対象としており、イメージは対象外であるため、いくつかの制限があります。また、アクセスされているバッファのデータを変更する境界を越えた書き込みやアトミックを許可してしまいます。より強力な堅牢性を求めるアプリケーションのために、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] があります。
+`robustBufferAccess` 機能は、バッファのみを対象としており、イメージは対象外であるため、いくつかの制限があります。また、アクセスされているバッファのデータを変更する境界を越えた書き込みやアトミックを許可してしまいます。より強力な堅牢性を求めるアプリケーションのために、link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] があります。
 
-イメージが境界を越えた場合、コア Vulkan では、ストアやアトミックがアクセスされるメモリに影響を与えないことがlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#textures-output-coordinate-validation[保証されています]。
+イメージが境界を越えた場合、コア Vulkan では、ストアやアトミックがアクセスされるメモリに影響を与えないことがlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#textures-output-coordinate-validation[保証されています]。
 
 == VK_EXT_image_robustness
 
 === robustImageAccess
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_EXT_image_robustness[VK_EXT_image_robustness] の link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustImageAccess[robustImageAccess] 機能は、イメージビューのサイズに対する境界を越えたアクセスをチェックします。イメージの境界をへのアクセスがあった場合、`(0, 0, 0, 0)` または `(0, 0, 0, 1)` を返します。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_EXT_image_robustness[VK_EXT_image_robustness] の link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-robustImageAccess[robustImageAccess] 機能は、イメージビューのサイズに対する境界を越えたアクセスをチェックします。イメージの境界をへのアクセスがあった場合、`(0, 0, 0, 0)` または `(0, 0, 0, 1)` を返します。
 
 `robustImageAccess` 機能は、無効な LOD へのアクセスに対して返される値については何の保証もありません。
 
 == VK_EXT_robustness2
 
-D3D12 などの他の API から移植されるアプリケーションなどでは、`robustBufferAccess` や `robustImageAccess` が提供するものよりも厳しい保証が必要になる場合があります。link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] 拡張機能では、以下のセクションで説明する3つの新しい堅牢性機能を公開することで、保証を追加しています。一部の実装では、これらの追加保証はパフォーマンスを犠牲にしています。追加の堅牢性を必要としないアプリケーションでは、可能な限り `robustBufferAccess` や `robustImageAccess` を代わりに使用することをお勧めします。
+D3D12 などの他の API から移植されるアプリケーションなどでは、`robustBufferAccess` や `robustImageAccess` が提供するものよりも厳しい保証が必要になる場合があります。link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] 拡張機能では、以下のセクションで説明する3つの新しい堅牢性機能を公開することで、保証を追加しています。一部の実装では、これらの追加保証はパフォーマンスを犠牲にしています。追加の堅牢性を必要としないアプリケーションでは、可能な限り `robustBufferAccess` や `robustImageAccess` を代わりに使用することをお勧めします。
 
 === robustBufferAccess2
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess2[robustBufferAccess2] 機能は `robustBufferAccess` のスーパーセットと見なすことができます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess2[robustBufferAccess2] 機能は `robustBufferAccess` のスーパーセットと見なすことができます。
 
-この機能を有効にすると、境界を越えた書き込みやアトミックがバッファのメモリを変更することができなくなります。また、`robustBufferAccess2` 機能は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess[仕様書に記載されている]ように、境界を越えたアクセスしたときに、さまざまなタイプのバッファに対して返さなければならない値を強制的に設定します。
+この機能を有効にすると、境界を越えた書き込みやアトミックがバッファのメモリを変更することができなくなります。また、`robustBufferAccess2` 機能は、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess[仕様書に記載されている]ように、境界を越えたアクセスしたときに、さまざまなタイプのバッファに対して返さなければならない値を強制的に設定します。
 
-バッファが範囲チェックされる場所のアライメントは実装によって異なるため、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceRobustness2PropertiesEXT.html[VkPhysicalDeviceRobustness2PropertiesEXT] から `robustUniformBufferAccessSizeAlignment` および `robustStorageBufferAccessSizeAlignment` をクエリすることが重要です。
+バッファが範囲チェックされる場所のアライメントは実装によって異なるため、link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPhysicalDeviceRobustness2PropertiesEXT.html[VkPhysicalDeviceRobustness2PropertiesEXT] から `robustUniformBufferAccessSizeAlignment` および `robustStorageBufferAccessSizeAlignment` をクエリすることが重要です。
 
 === robustImageAccess2
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustImageAccess2[robustImageAccess2] 機能は `robustImageAccess` のスーパーセットと見なすことができます。この機能は、アクセスしているイメージビューのサイズに対する境界を越えたかどうかのチェックをベースに、どのような値を返すことができるかについて、より厳しい要件を追加しています。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-robustImageAccess2[robustImageAccess2] 機能は `robustImageAccess` のスーパーセットと見なすことができます。この機能は、アクセスしているイメージビューのサイズに対する境界を越えたかどうかのチェックをベースに、どのような値を返すことができるかについて、より厳しい要件を追加しています。
 
 `robustImageAccess2` では、R、RG、RGB フォーマットへの境界を越えたアクセスは `(0, 0, 0, 1)` を返します。`VK_FORMAT_R8G8B8A8_UNORM` のような RGBA フォーマットの場合は、`(0, 0, 0, 0)` を返します。
 
@@ -62,6 +62,6 @@ link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.ht
 
 === nullDescriptor
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-nullDescriptor[nullDescriptor] 機能が有効になっていない場合、`VkDescriptorSet` を更新するときには、たとえディスクリプタがシェーダで静的に使用されていなくても、対応するすべてのリソースは非ヌルでなければなりません。この機能により、ディスクリプタをヌルのリソースまたはビューと対応させることができます。ヌルディスクリプタからのロードはゼロ値を返し、ヌルディスクリプタへのストアとアトミックは破棄されます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-nullDescriptor[nullDescriptor] 機能が有効になっていない場合、`VkDescriptorSet` を更新するときには、たとえディスクリプタがシェーダで静的に使用されていなくても、対応するすべてのリソースは非ヌルでなければなりません。この機能により、ディスクリプタをヌルのリソースまたはビューと対応させることができます。ヌルディスクリプタからのロードはゼロ値を返し、ヌルディスクリプタへのストアとアトミックは破棄されます。
 
 `nullDescriptor` 機能は、`vkCmdBindVertexBuffers::pBuffers` がヌルの場合にも、頂点入力バインディングへのアクセスを可能にします。

--- a/lang/jp/chapters/shader_memory_layout.adoc
+++ b/lang/jp/chapters/shader_memory_layout.adoc
@@ -7,12 +7,12 @@ ifndef::chapters[:chapters:]
 [[shader-memory-layout]]
 = シェーダメモリレイアウト
 
-実装がインターフェイスからメモリにアクセスするとき、**メモリレイアウト**を知る必要があります。これには、**オフセット**、**ストライド**、 **アライメント**が含まれます。Vulkan Spec には link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-layout[レイアウトのセクション] がありますが、さまざまな拡張機能による複雑化により、理解が困難な場合があります。この章では、いくつかの高レベルシェーディング言語（GLSL）の例を用いて、Vulkan が使用するすべてのメモリレイアウトの概念を説明します。
+実装がインターフェイスからメモリにアクセスするとき、**メモリレイアウト**を知る必要があります。これには、**オフセット**、**ストライド**、 **アライメント**が含まれます。Vulkan Spec には link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-layout[レイアウトのセクション] がありますが、さまざまな拡張機能による複雑化により、理解が困難な場合があります。この章では、いくつかの高レベルシェーディング言語（GLSL）の例を用いて、Vulkan が使用するすべてのメモリレイアウトの概念を説明します。
 
 [[alignment-requirements]]
 == アライメントの要件
 
-Vulkan には、インターフェイスオブジェクトをレイアウトできる3つのlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-alignment-requirements[アライメント要件]があります。
+Vulkan には、インターフェイスオブジェクトをレイアウトできる3つのlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-alignment-requirements[アライメント要件]があります。
 
 - 拡張アライメント (別名 `std140`)
 - ベースアライメント (別名 `std430`)
@@ -35,7 +35,7 @@ Vulkan 1.2でコアに昇格
 ====
 
 この拡張機能により、UBOで `std430` メモリレイアウトを使用できるようになります。
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-standard-layout[Vulkan Standard Buffer Layout Interface]は、このガイドには含まれていません。プッシュ定数や SSBO など、他のストレージアイテムはすでに std430 スタイルのレイアウトが可能なため、これらのメモリレイアウトの変更は `Uniforms` にのみ適用されます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-standard-layout[Vulkan Standard Buffer Layout Interface]は、このガイドには含まれていません。プッシュ定数や SSBO など、他のストレージアイテムはすでに std430 スタイルのレイアウトが可能なため、これらのメモリレイアウトの変更は `Uniforms` にのみ適用されます。
 
 `UniformBufferStandardLayout` 機能が必要な場合の一例として、アプリケーションが UBO の配列のストライドを `extended alignment` に制限したくない場合があります。
 

--- a/lang/jp/chapters/sparse_resources.adoc
+++ b/lang/jp/chapters/sparse_resources.adoc
@@ -6,11 +6,11 @@ ifndef::chapters[:chapters:]
 [[sparse-resources]]
 = スパースリソース（Sparse Resources）
 
-Vulkan のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory[スパースリソース]は、`VkBuffer` と `VkImage` オブジェクトを作成する方法で、1つまたは複数の `VkDeviceMemory` に非連続的にバインドすることができます。スパースリソースにはさまざまな側面や機能があり、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-sparseresourcefeatures[仕様書]ではそれらがうまく説明されています。link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#_sparse_resource_implementation_guidelines[実装ガイドライン]に記載されているように、ほとんどの実装では、スパースリソースを使用してメモリの直線的な仮想アドレス範囲をアプリケーションに公開する一方で、バインド時には各スパースブロックを物理ページにマッピングします。
+Vulkan のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#sparsememory[スパースリソース]は、`VkBuffer` と `VkImage` オブジェクトを作成する方法で、1つまたは複数の `VkDeviceMemory` に非連続的にバインドすることができます。スパースリソースにはさまざまな側面や機能があり、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#sparsememory-sparseresourcefeatures[仕様書]ではそれらがうまく説明されています。link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#_sparse_resource_implementation_guidelines[実装ガイドライン]に記載されているように、ほとんどの実装では、スパースリソースを使用してメモリの直線的な仮想アドレス範囲をアプリケーションに公開する一方で、バインド時には各スパースブロックを物理ページにマッピングします。
 
 == スパースメモリのバインド
 
-通常のリソースが `vkBindBufferMemory()` や `vkBindImageMemory()` を呼び出すのとは異なり、スパースメモリは link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-resource-binding[キュー操作] `vkQueueBindSparse()` を介してバインドされます。この方法の主な利点は、アプリケーションがそのライフタイムを通じてメモリをスパースリソースに再バインドできることです。
+通常のリソースが `vkBindBufferMemory()` や `vkBindImageMemory()` を呼び出すのとは異なり、スパースメモリは link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#sparsememory-resource-binding[キュー操作] `vkQueueBindSparse()` を介してバインドされます。この方法の主な利点は、アプリケーションがそのライフタイムを通じてメモリをスパースリソースに再バインドできることです。
 
 この際、アプリケーション側でいくつか配慮が必要です。アプリケーションは、他のキューがバインディングの変更と同時にメモリの範囲をアクセスしないことを保証するために、**同期プリミティブを使用しなければなりません**。また、`vkDeviceMemory` オブジェクトを `vkFreeMemory()` で解放しても、メモリオブジェクトにバインドされたリソース（またはリソース領域）は**アンバインドされません** 。アプリケーションは、解放されたメモリにバインドされたリソースにアクセスしてはいけません。
 
@@ -32,7 +32,7 @@ image::../../../chapters/images/sparse_resources_buffer.png[sparse_resources_buf
 
 ==== Mip Tail Region
 
-スパースイメージを使ってミップレベルを個別に更新すると、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-miptail[mip tail region]のような結果になります。仕様書の図では、さまざまな例が記載されています。
+スパースイメージを使ってミップレベルを個別に更新すると、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#sparsememory-miptail[mip tail region]のような結果になります。仕様書の図では、さまざまな例が記載されています。
 
 ==== スパースリソースの基本的な例
 

--- a/lang/jp/chapters/spirv_extensions.adoc
+++ b/lang/jp/chapters/spirv_extensions.adoc
@@ -13,7 +13,7 @@ SPIR-V は中間言語であり、API ではないことを忘れてはいけま
 
 == SPIR-V 拡張機能の例
 
-この例では、 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_8bit_storage.html[VK_KHR_8bit_storage] と link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] を使用して、`UniformAndStorageBuffer8BitAccess` 機能を公開します。SPIR-V を逆アセンブルすると、以下のようになります。
+この例では、 link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_8bit_storage.html[VK_KHR_8bit_storage] と link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] を使用して、`UniformAndStorageBuffer8BitAccess` 機能を公開します。SPIR-V を逆アセンブルすると、以下のようになります。
 
 [source,swift]
 ----
@@ -36,11 +36,11 @@ OpExtension  "SPV_KHR_8bit_storage"
 
 シェーダの機能によっては、`OpExtension` または `OpCapability` だけが必要な場合があります。この例では、`UniformAndStorageBuffer8BitAccess` は link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] 拡張機能に含まれます。
 
-SPIR-V 拡張機能がサポートされているかどうかを確認するには、Vulkan Spec のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-extensions[対応している SPIR-V 拡張機能表]をご覧ください。
+SPIR-V 拡張機能がサポートされているかどうかを確認するには、Vulkan Spec のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#spirvenv-extensions[対応している SPIR-V 拡張機能表]をご覧ください。
 
 image::../../../chapters/images/spirv_extensions_8bit_extension.png[spirv_extensions_8bit_extension]
 
-また、Vulkan Spec のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-capabilities[対応している SPIR-V 機能表]もご覧ください。
+また、Vulkan Spec のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#spirvenv-capabilities[対応している SPIR-V 機能表]もご覧ください。
 
 image::../../../chapters/images/spirv_extensions_8bit_capability.png[spirv_extensions_8bit_capability]
 

--- a/lang/jp/chapters/synchronization.adoc
+++ b/lang/jp/chapters/synchronization.adoc
@@ -7,9 +7,9 @@ ifndef::chapters[:chapters:]
 [[synchronization]]
 = 同期
 
-同期は、Vulkan を使用する上で最も強力な部分の一つですが、同時に最も複雑な部分でもあります。アプリケーションは、さまざまな link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#synchronization[Vulkan 同期プリミティブ]を使用して同期を管理する責任があります。同期の使い方を誤ると、見つけにくいバグが発生したり、GPUが不必要にアイドル状態になってパフォーマンスが低下したりします。
+同期は、Vulkan を使用する上で最も強力な部分の一つですが、同時に最も複雑な部分でもあります。アプリケーションは、さまざまな link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#synchronization[Vulkan 同期プリミティブ]を使用して同期を管理する責任があります。同期の使い方を誤ると、見つけにくいバグが発生したり、GPUが不必要にアイドル状態になってパフォーマンスが低下したりします。
 
-link:https://github.com/KhronosGroup/Vulkan-Docs/wiki/Synchronization-Examples[同期の例]とlink:https://www.khronos.org/blog/understanding-vulkan-synchronization[Vulkan Synchronization の理解]というブログ記事が Khronos によって提供されており、同期プリミティブの使用方法が紹介されています。また、Tobias Hector 氏による過去の Vulkan に関する講演のプレゼンテーションもあります。link:https://www.khronos.org/assets/uploads/developers/library/2017-vulkan-devu-vancouver/009%20-%20Synchronization%20-%20Keeping%20Your%20Device%20Fed.pdf[パート1スライド] (link:https://www.youtube.com/watch?v=YkJ4hKCPjm0[動画]) とlink:https://www.khronos.org/assets/uploads/developers/library/2018-vulkanised/06-Keeping%20Your%20Device%20Fed%20v4_Vulkanised2018.pdf[パート2スライド] (link:https://www.youtube.com/watch?v=5GDg4OxkSEc[動画]) 
+link:https://github.com/KhronosGroup/Vulkan-Docs/wiki/Synchronization-Examples[同期の例]とlink:https://www.khronos.org/blog/understanding-vulkan-synchronization[Vulkan Synchronization の理解]というブログ記事が Khronos によって提供されており、同期プリミティブの使用方法が紹介されています。また、Tobias Hector 氏による過去の Vulkan に関する講演のプレゼンテーションもあります。link:https://www.khronos.org/assets/uploads/developers/library/2017-vulkan-devu-vancouver/009%20-%20Synchronization%20-%20Keeping%20Your%20Device%20Fed.pdf[パート1スライド] (link:https://www.youtube.com/watch?v=YkJ4hKCPjm0[動画]) とlink:https://www.khronos.org/assets/uploads/developers/library/2018-vulkanised/06-Keeping%20Your%20Device%20Fed%20v4_Vulkanised2018.pdf[パート2スライド] (link:https://www.youtube.com/watch?v=5GDg4OxkSEc[動画])
 
 以下は `VkEvent`、`VkFence`、`VkSemaphore` の違いを示す概要図です。
 
@@ -21,7 +21,7 @@ Khronos Validation Layer は、link:https://vulkan.lunarg.com/doc/sdk/latest/win
 
 == パイプラインバリア
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#synchronization-pipeline-barriers[パイプラインバリア]は、コマンドバッファが実行される際に、どのパイプラインステージが前のパイプラインステージを待つ必要があるかを制御します。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#synchronization-pipeline-barriers[パイプラインバリア]は、コマンドバッファが実行される際に、どのパイプラインステージが前のパイプラインステージを待つ必要があるかを制御します。
 
 image::../../../chapters/images/synchronization_pipeline_barrieres.png[synchronization_pipeline_barrieres.png]
 

--- a/lang/jp/chapters/threading.adoc
+++ b/lang/jp/chapters/threading.adoc
@@ -9,13 +9,13 @@ ifndef::chapters[:chapters:]
 
 Vulkan と OpenGL の大きな違いの一つは、Vulkan がシングルスレッドのステートマシンシステムに限定されていないことです。アプリケーションにスレッドを実装する前に、Vulkan でスレッドがどのように機能するかを理解することが重要です。
 
-Vulkan Spec のlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#fundamentals-threadingbehavior[スレッドの挙動] では、Vulkan の外部同期要素をアプリケーションがどのように管理するかを詳しく説明しています。重要なのは、Vulkan のマルチスレッドはホスト側のスケーリングを提供するだけであり、デバイスと相互に作用するものは依然としてxref:{chapters}sychronization.adoc#synchronization[正しく同期される]必要があるということです。
+Vulkan Spec のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fundamentals-threadingbehavior[スレッドの挙動] では、Vulkan の外部同期要素をアプリケーションがどのように管理するかを詳しく説明しています。重要なのは、Vulkan のマルチスレッドはホスト側のスケーリングを提供するだけであり、デバイスと相互に作用するものは依然としてxref:{chapters}sychronization.adoc#synchronization[正しく同期される]必要があるということです。
 
 Vulkan の実装では、マルチスレッドを導入することは想定されていないため、アプリがマルチ CPU のパフォーマンスを求める場合は、アプリがスレッドの管理を担当することになります。
 
 == コマンドプール
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#commandbuffers-pools[コマンドプール]とは、複数のスレッドにまたがってコマンドバッファを記録できるシステムです。1つのコマンドプールは外部で同期していなければならず、複数のスレッドから同時にアクセスすることはできません。ホストスレッドごとに独立したコマンドプールを使用することで、コストのかかるロックをかけずに複数のコマンドバッファを並行して作成することができます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#commandbuffers-pools[コマンドプール]とは、複数のスレッドにまたがってコマンドバッファを記録できるシステムです。1つのコマンドプールは外部で同期していなければならず、複数のスレッドから同時にアクセスすることはできません。ホストスレッドごとに独立したコマンドプールを使用することで、コストのかかるロックをかけずに複数のコマンドバッファを並行して作成することができます。
 
 これは、コマンドバッファを複数のスレッドで記録しつつ、比較的軽いスレッドでサブミットを処理できるというアイディアです。
 
@@ -25,4 +25,4 @@ Khronos のlink:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples
 
 == ディスクリプタプール
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#VkDescriptorPool[ディスクリプタプール]は、ディスクリプタセットの割り当て、解放、リセット、および更新に使用されます。複数のディスクリプタプールを作成することで、各アプリケーションのホストスレッドは、各ディスクリプタプールのディスクリプタセットを同時に管理することができます。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkDescriptorPool[ディスクリプタプール]は、ディスクリプタセットの割り当て、解放、リセット、および更新に使用されます。複数のディスクリプタプールを作成することで、各アプリケーションのホストスレッドは、各ディスクリプタプールのディスクリプタセットを同時に管理することができます。

--- a/lang/jp/chapters/validation_overview.adoc
+++ b/lang/jp/chapters/validation_overview.adoc
@@ -14,7 +14,7 @@ ifndef::chapters[:chapters:]
 
 == 有効な使用法（Valid Usage: VU）
 
-**VU** は Vulkan Spec で次のように明確にlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-validusage[定義]されています。
+**VU** は Vulkan Spec で次のように明確にlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fundamentals-validusage[定義]されています。
 
 [NOTE]
 ====
@@ -35,7 +35,7 @@ ifndef::chapters[:chapters:]
 
 `VUID` は、有効な使用法ごとに与えられる唯一の ID です。これにより、仕様書の中の有効な使用法を簡単に探すことができます。
 
-`VUID-vkBindImageMemory-memoryOffset-01046` を例にとると、HTML 版仕様書のアンカーに VUID を追加する（link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046[vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046]）だけで、VUID にジャンプすることができます。
+`VUID-vkBindImageMemory-memoryOffset-01046` を例にとると、HTML 版仕様書のアンカーに VUID を追加する（link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046[vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046]）だけで、VUID にジャンプすることができます。
 
 [[khronos-validation-layer]]
 == Khronos Validation Layer
@@ -62,7 +62,7 @@ Khronos Validation Layer は、以前は複数のレイヤで構成されてい�
 
 === 例1 - 暗黙的な有効な使用法
 
-この例では、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-implicit-validity[暗黙的な有効な使用法] がトリガーされる場合を示しています。VUID の最後には数字が入りません。
+この例では、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fundamentals-implicit-validity[暗黙的な有効な使用法] がトリガーされる場合を示しています。VUID の最後には数字が入りません。
 
 [source]
 ----
@@ -76,8 +76,8 @@ html/vkspec.html#VUID-vkBindBufferMemory-memory-parameter)
   * 最初に気付くのは、VUID がメッセージの最初に表示されていることです。（`VUID-vkBindBufferMemory-memory-parameter`）
   ** また、メッセージの最後には、仕様の VUID へのリンクがあります。
   * `The Vulkan spec states:` は、スペックから引用したVUIDです。
-  * `VK_OBJECT_TYPE_INSTANCE` は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#_debugging[VkObjectType] です。
-  * `Invalid VkDeviceMemory Object 0x60000000006` は、どの `VkDeviceMemory` ハンドルがエラーの原因であるかを示すのに役立つ link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-objectmodel-overview[Dispatchable Handle] です。
+  * `VK_OBJECT_TYPE_INSTANCE` は、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#_debugging[VkObjectType] です。
+  * `Invalid VkDeviceMemory Object 0x60000000006` は、どの `VkDeviceMemory` ハンドルがエラーの原因であるかを示すのに役立つ link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fundamentals-objectmodel-overview[Dispatchable Handle] です。
 
 === 例2 - 明示的な有効な使用法
 
@@ -153,7 +153,7 @@ endif::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
 
 == 特殊用途タグ
 
-link:https://vulkan.lunarg.com/doc/sdk/latest/windows/best_practices.html[ベストプラクティスレイヤ]は、アプリケーションがlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-specialuse[特殊用途タグ]を持つ拡張機能を使用しようとすると、警告を発生させます。このような拡張機能の例として、エミュレーションレイヤのためだけに設計された xref:{chapters}extensions/translation_layer_extensions.adoc#vk_ext_transform_feedback[VK_EXT_transform_feedback] が挙げられます。アプリケーションの使用目的が特殊用途に該当する場合、以下の方法で警告を無視することができます。
+link:https://vulkan.lunarg.com/doc/sdk/latest/windows/best_practices.html[ベストプラクティスレイヤ]は、アプリケーションがlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-specialuse[特殊用途タグ]を持つ拡張機能を使用しようとすると、警告を発生させます。このような拡張機能の例として、エミュレーションレイヤのためだけに設計された xref:{chapters}extensions/translation_layer_extensions.adoc#vk_ext_transform_feedback[VK_EXT_transform_feedback] が挙げられます。アプリケーションの使用目的が特殊用途に該当する場合、以下の方法で警告を無視することができます。
 
 `VK_EXT_debug_report` による特殊用途に関する警告の無視
 

--- a/lang/jp/chapters/versions.adoc
+++ b/lang/jp/chapters/versions.adoc
@@ -7,13 +7,13 @@ ifndef::chapters[:chapters:]
 [[versions]]
 = バージョン
 
-Vulkan は、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions-versionnumbers[メジャー、マイナー、パッチ]に分かれたバージョンシステムを採用しています。現在は4つのマイナーバージョン（1.0、1.1、1.2、1.3）がリリースされており、それぞれ後方互換性があります。アプリケーションはlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#vkEnumerateInstanceVersion[vkEnumerateInstanceVersion] を使用して、サポートされている Vulkan インスタンスのバージョンを確認することができます。また、LunarG によるlink:https://www.lunarg.com/wp-content/uploads/2019/02/Vulkan-1.1-Compatibility-Statement_01_19.pdf[ホワイトペーパー]では、サポートされているバージョンをクエリして確認する方法が紹介されています。マイナーバージョンをまたいで作業する場合は、いくつか注意すべき点があります。
+Vulkan は、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-versionnumbers[メジャー、マイナー、パッチ]に分かれたバージョンシステムを採用しています。現在は4つのマイナーバージョン（1.0、1.1、1.2、1.3）がリリースされており、それぞれ後方互換性があります。アプリケーションはlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkEnumerateInstanceVersion[vkEnumerateInstanceVersion] を使用して、サポートされている Vulkan インスタンスのバージョンを確認することができます。また、LunarG によるlink:https://www.lunarg.com/wp-content/uploads/2019/02/Vulkan-1.1-Compatibility-Statement_01_19.pdf[ホワイトペーパー]では、サポートされているバージョンをクエリして確認する方法が紹介されています。マイナーバージョンをまたいで作業する場合は、いくつか注意すべき点があります。
 
 == インスタンスとデバイス
 
 インスタンスレベルのバージョンと、デバイスレベルのバージョンには違いがあるということが重要です。ローダと実装が異なるバージョンをサポートする可能性があります。
 
-Vulkan Spec の link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions-queryingversionsupport[バージョンサポートのクエリ]では、インスタンスレベルとデバイスレベルの両方でサポートされているバージョンをクエリする方法を詳しく説明しています。
+Vulkan Spec の link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-queryingversionsupport[バージョンサポートのクエリ]では、インスタンスレベルとデバイスレベルの両方でサポートされているバージョンをクエリする方法を詳しく説明しています。
 
 == ヘッダ
 
@@ -23,7 +23,7 @@ Vulkan Spec の link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vksp
 
 == 拡張機能
 
-Vulkan のマイナーバージョン間では、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#versions-1.1[一部の拡張機能]がlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions[コア]にlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-compatibility-promotions[昇格] します。新しいマイナーバージョンの Vulkan をターゲットにする場合、アプリケーションはインスタンスやデバイスの作成時に新しく昇格した拡張機能を有効にする必要はありません。ただし、アプリケーションが後方互換性を維持したい場合は、拡張機能を有効にする必要があります。
+Vulkan のマイナーバージョン間では、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#versions-1.1[一部の拡張機能]がlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions[コア]にlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotions[昇格] します。新しいマイナーバージョンの Vulkan をターゲットにする場合、アプリケーションはインスタンスやデバイスの作成時に新しく昇格した拡張機能を有効にする必要はありません。ただし、アプリケーションが後方互換性を維持したい場合は、拡張機能を有効にする必要があります。
 
 各バージョンの新機能の概要については、xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan Release Summary] をご覧ください。
 
@@ -53,17 +53,17 @@ typedef void (VKAPI_PTR *PFN_vkGetPhysicalDeviceFeatures2KHR)(VkPhysicalDevice p
 
 == 機能
 
-マイナーバージョン間で、いくつかの機能ビットが追加されたり、削除されたり、オプションになったり、必須になったりする可能性があります。変更された機能の詳細は、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#versions[Core Revisions] のセクションに記載されています。
+マイナーバージョン間で、いくつかの機能ビットが追加されたり、削除されたり、オプションになったり、必須になったりする可能性があります。変更された機能の詳細は、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#versions[Core Revisions] のセクションに記載されています。
 
-Vulkan Spec の link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#features-requirements[Feature Requirements] セクションでは、マイナーバージョン間で実装に要求されている機能のリストを見ることができます。
+Vulkan Spec の link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#features-requirements[Feature Requirements] セクションでは、マイナーバージョン間で実装に要求されている機能のリストを見ることができます。
 
 == 制限
 
-現在、Vulkanのすべてのバージョンで、最小/最大の制限要件は同じですが、変更があった場合は Vulkan Spec の link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#limits-minmax[Limit Requirements] セクションに記載されます。
+現在、Vulkanのすべてのバージョンで、最小/最大の制限要件は同じですが、変更があった場合は Vulkan Spec の link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#limits-minmax[Limit Requirements] セクションに記載されます。
 
 == SPIR-V
 
-すべての Vulkan のマイナーバージョンは、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#spirvenv[サポートされなければならない SPIR-V] のバージョンに対応しています。
+すべての Vulkan のマイナーバージョンは、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#spirvenv[サポートされなければならない SPIR-V] のバージョンに対応しています。
 
   * Vulkan 1.0は SPIR-V 1.0をサポートしています。
   * Vulkan 1.1は SPIR-V 1.3以下をサポートしています。

--- a/lang/jp/chapters/vertex_input_data_processing.adoc
+++ b/lang/jp/chapters/vertex_input_data_processing.adoc
@@ -6,7 +6,7 @@ ifndef::chapters[:chapters:]
 [[vertex-input-data-processing]]
 = 頂点入力データ処理
 
-本章では、グラフィックスパイプラインを使用する際に、アプリケーションがどのようにデータを頂点シェーダにマッピングするかを理解するために、仕様書のlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex[固定機能頂点処理]の章の概要を説明します。
+本章では、グラフィックスパイプラインを使用する際に、アプリケーションがどのようにデータを頂点シェーダにマッピングするかを理解するために、仕様書のlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fxvertex[固定機能頂点処理]の章の概要を説明します。
 
 また、Vulkan はさまざまな使い方ができるツールであることも忘れてはいけません。以下は、教育目的のための、頂点データをどのようにレイアウトできるかの例です。
 
@@ -314,7 +314,7 @@ ____
 
 == コンポーネント割り当て
 
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex-attrib-location[仕様書]では、`Component` 割り当てについてさらに詳しく説明されています。以下にその概要をご紹介します。
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#fxvertex-attrib-location[仕様書]では、`Component` 割り当てについてさらに詳しく説明されています。以下にその概要をご紹介します。
 
 === コンポーネントの埋められ方
 
@@ -324,7 +324,7 @@ ____
 `VK_FORMAT_R32G32B32_SFLOAT` は3つのコンポーネントを持ちますが、`vec2` は2つしかありません。
 ____
 
-その逆のケースでは、仕様書には、欠落しているコンポーネントをどのように拡張するかをlink:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-conversion-to-rgba[示す表がある。]
+その逆のケースでは、仕様書には、欠落しているコンポーネントをどのように拡張するかをlink:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#textures-conversion-to-rgba[示す表がある。]
 
 例としてはこのようになります。
 

--- a/lang/jp/chapters/vulkan_cts.adoc
+++ b/lang/jp/chapters/vulkan_cts.adoc
@@ -14,4 +14,4 @@ link:https://github.com/KhronosGroup/VK-GL-CTS/tree/master/external/vulkancts[Vu
 
 image::../../../chapters/images/vulkan_cts_overview.png[vulkan_cts_overview.png]
 
-アプリケーションは `VK_KHR_driver_properties` 拡張機能により、 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] プロパティを使用して、実装が合格した CTS のバージョンをクエリすることができます（これは Vulkan 1.2でコアに昇格しました）。
+アプリケーションは `VK_KHR_driver_properties` 拡張機能により、 link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] プロパティを使用して、実装が合格した CTS のバージョンをクエリすることができます（これは Vulkan 1.2でコアに昇格しました）。

--- a/lang/jp/chapters/vulkan_release_summary.adoc
+++ b/lang/jp/chapters/vulkan_release_summary.adoc
@@ -7,7 +7,7 @@ ifndef::chapters[:chapters:]
 [[vulkan-release-summary]]
 = Vulkan Release Summary
 
-Vulkan のマイナーリリースバージョンは、それぞれ異なる拡張機能をコアにlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[昇格]させました。つまり、アプリケーションが少なくともその Vulkan バージョンを要求していれば（そのバージョンが実装でサポートされていれば）、昇格された機能を使用するために拡張機能を有効にする必要はなくなりました。
+Vulkan のマイナーリリースバージョンは、それぞれ異なる拡張機能をコアにlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[昇格]させました。つまり、アプリケーションが少なくともその Vulkan バージョンを要求していれば（そのバージョンが実装でサポートされていれば）、昇格された機能を使用するために拡張機能を有効にする必要はなくなりました。
 
 以下の要約には、それぞれのコアバージョンに追加された拡張機能のリストと、その理由が記載されています。このリストは Vulkan Spec から引用していますが、リンクは Vulkan Guide のさまざまなページにジャンプします。
 
@@ -15,7 +15,7 @@ Vulkan のマイナーリリースバージョンは、それぞれ異なる拡�
 
 [NOTE]
 ====
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.1[Vulkan Spec Section]
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#versions-1.1[Vulkan Spec Section]
 ====
 
 Vulkan 1.1は2018年3月7日にリリースされました。
@@ -39,7 +39,7 @@ Vulkan 1.1では、以下の拡張機能のほかに、xref:{chapters}subgroups.
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance1]
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance2]
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance3]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_multiview.html#_description[VK_KHR_multiview]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_multiview.html#_description[VK_KHR_multiview]
   * xref:{chapters}shader_memory_layout.adoc#VK_KHR_relaxed_block_layout[VK_KHR_relaxed_block_layout]
   * xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc#VK_KHR_sampler_ycbcr_conversion[VK_KHR_sampler_ycbcr_conversion]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_draw_parameters[VK_KHR_shader_draw_parameters]
@@ -50,15 +50,15 @@ Vulkan 1.1では、以下の拡張機能のほかに、xref:{chapters}subgroups.
 
 [NOTE]
 ====
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.2[Vulkan Spec Section]
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#versions-1.2[Vulkan Spec Section]
 ====
 
 Vulkan 1.2は2020年1月15日にリリースされました。
 
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_8bit_storage[VK_KHR_8bit_storage]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address]
   * xref:{chapters}extensions/cleanup.adoc#pnext-expansions[VK_KHR_create_renderpass2]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_depth_stencil_resolve.html#_description[VK_KHR_depth_stencil_resolve]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_depth_stencil_resolve.html#_description[VK_KHR_depth_stencil_resolve]
   * xref:{chapters}extensions/VK_KHR_draw_indirect_count.adoc#VK_KHR_draw_indirect_count[VK_KHR_draw_indirect_count]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_driver_properties[VK_KHR_driver_properties]
   * xref:{chapters}extensions/VK_KHR_image_format_list.adoc#VK_KHR_image_format_list[VK_KHR_image_format_list]
@@ -85,7 +85,7 @@ Vulkan 1.2は2020年1月15日にリリースされました。
 
 [NOTE]
 ====
-link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.3[Vulkan Spec Section]
+link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#versions-1.3[Vulkan Spec Section]
 ====
 
 
@@ -95,7 +95,7 @@ link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.ht
   * link:https://www.khronos.org/blog/streamlining-render-passes[VK_KHR_dynamic_rendering]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_format_feature_flags2[VK_KHR_format_feature_flags2]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_maintenance4[VK_KHR_maintenance4]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_integer_dot_product.html#_description[VK_KHR_shader_integer_dot_product]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_KHR_shader_integer_dot_product.html#_description[VK_KHR_shader_integer_dot_product]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_non_semantic_info[VK_KHR_shader_non_semantic_info]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_terminate_invocation[VK_KHR_shader_terminate_invocation]
   * xref:{chapters}extensions/VK_KHR_synchronization2.adoc[VK_KHR_synchronization2]
@@ -104,12 +104,12 @@ link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.ht
   * xref:{chapters}dynamic_state.adoc#states-that-are-dynamic[VK_EXT_extended_dynamic_state]
   * xref:{chapters}dynamic_state.adoc#states-that-are-dynamic[VK_EXT_extended_dynamic_state2]
   * xref:{chapters}extensions/VK_EXT_inline_uniform_block.adoc#VK_EXT_inline_uniform_block[VK_EXT_inline_uniform_block]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_cache_control.html#_description[VK_EXT_pipeline_creation_cache_control]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_feedback.html#_description[VK_EXT_pipeline_creation_feedback]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_private_data.html#_description[VK_EXT_private_data]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_pipeline_creation_cache_control.html#_description[VK_EXT_pipeline_creation_cache_control]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_pipeline_creation_feedback.html#_description[VK_EXT_pipeline_creation_feedback]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_private_data.html#_description[VK_EXT_private_data]
   * xref:{chapters}extensions/shader_features.adoc#VK_EXT_shader_demote_to_helper_invocation[VK_EXT_shader_demote_to_helper_invocation]
   * xref:{chapters}subgroups.adoc#VK_EXT_subgroup_size_control[VK_EXT_subgroup_size_control]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_texel_buffer_alignment.html#_description[VK_EXT_texel_buffer_alignment]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_texture_compression_astc_hdr.html#_description[VK_EXT_texture_compression_astc_hdr]
-  * link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_tooling_info.html#_description[VK_EXT_tooling_info]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_texel_buffer_alignment.html#_description[VK_EXT_texel_buffer_alignment]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_texture_compression_astc_hdr.html#_description[VK_EXT_texture_compression_astc_hdr]
+  * link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_EXT_tooling_info.html#_description[VK_EXT_tooling_info]
   * xref:{chapters}extensions/cleanup.adoc#VK_EXT_4444_formats-and-VK_EXT_ycbcr_2plane_444_formats[VK_EXT_ycbcr_2plane_444_formats]

--- a/lang/jp/chapters/what_is_spirv.adoc
+++ b/lang/jp/chapters/what_is_spirv.adoc
@@ -11,13 +11,13 @@ ifndef::chapters[:chapters:]
 SPIR-V の詳細については、link:https://github.com/KhronosGroup/SPIRV-Guide[SPIRV-Guide] をご覧ください。
 ====
 
-link:https://www.khronos.org/registry/SPIR-V/[SPIR-V] は、グラフィックスシェーダステージとコンピュートカーネルのバイナリ中間表現です。Vulkan では、アプリケーションは GLSL や xref:{chapters}hlsl.adoc[HLSL] などの高レベルシェーディング言語でシェーダを書くことができますが、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#vkCreateShaderModule[vkCreateShaderModule] を使用する際には SPIR-V のバイナリが必要です。Khronos は、SPIR-V とその利点、および表現の高レベルな説明についてのlink:https://www.khronos.org/registry/SPIR-V/papers/WhitePaper.pdf[ホワイトペーパー]を用意しています。また、Vulkan DevDay 2016での2つの素晴らしい Khronos のプレゼンテーションがlink:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/3-Intro-to-spir-v-shaders.pdf[こちら]とlink:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/4-Using-spir-v-with-spirv-cross.pdf[こちら]（link:https://www.youtube.com/watch?v=XRpVwdduzgU[両方の動画]）です。
+link:https://www.khronos.org/registry/SPIR-V/[SPIR-V] は、グラフィックスシェーダステージとコンピュートカーネルのバイナリ中間表現です。Vulkan では、アプリケーションは GLSL や xref:{chapters}hlsl.adoc[HLSL] などの高レベルシェーディング言語でシェーダを書くことができますが、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateShaderModule[vkCreateShaderModule] を使用する際には SPIR-V のバイナリが必要です。Khronos は、SPIR-V とその利点、および表現の高レベルな説明についてのlink:https://www.khronos.org/registry/SPIR-V/papers/WhitePaper.pdf[ホワイトペーパー]を用意しています。また、Vulkan DevDay 2016での2つの素晴らしい Khronos のプレゼンテーションがlink:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/3-Intro-to-spir-v-shaders.pdf[こちら]とlink:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/4-Using-spir-v-with-spirv-cross.pdf[こちら]（link:https://www.youtube.com/watch?v=XRpVwdduzgU[両方の動画]）です。
 
 == SPIR-V のインターフェイスと機能
 
-Vulkan には、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#interfaces[Vulkan と SPIR-V シェーダとのインターフェイス]を定義するセクションがあります。SPIR-V とのインターフェイスは、ほとんどの場合シェーダが一緒にコンパイルされるパイプラインの作成時に使用されます。
+Vulkan には、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces[Vulkan と SPIR-V シェーダとのインターフェイス]を定義するセクションがあります。SPIR-V とのインターフェイスは、ほとんどの場合シェーダが一緒にコンパイルされるパイプラインの作成時に使用されます。
 
-SPIR-V は Vulkan だけでなく他のターゲットも持っているため、多くの機能を持っています。Vulkan が必要とする機能については、link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#spirvenv-capabilities[付録]を参照してください。Vulkan のいくつかの拡張機能と機能は、SPIR-V の機能がサポートされているかどうかをチェックするために用意されています。
+SPIR-V は Vulkan だけでなく他のターゲットも持っているため、多くの機能を持っています。Vulkan が必要とする機能については、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#spirvenv-capabilities[付録]を参照してください。Vulkan のいくつかの拡張機能と機能は、SPIR-V の機能がサポートされているかどうかをチェックするために用意されています。
 
 == コンパイラ
 

--- a/lang/jp/chapters/what_is_vulkan.adoc
+++ b/lang/jp/chapters/what_is_vulkan.adoc
@@ -13,7 +13,7 @@ Vulkan は、企業でも言語でもなく、最新の GPU ハードウェア�
 
 == Vulkan の中心
 
-本質的に、Vulkan は適合するハードウェアの実装が従う link:https://www.khronos.org/registry/vulkan/#apispecs[API 仕様]です。公開されている仕様は、Vulkan Specification リポジトリの公式公開コピーの link:https://github.com/KhronosGroup/Vulkan-Docs[Vulkan-Docs] にある link:https://github.com/KhronosGroup/Vulkan-Docs/blob/main/xml/vk.xml[./xml/vk.xml] Vulkan Registry ファイルから生成されています。また、link:https://www.khronos.org/registry/vulkan/specs/1.3/registry.html[XML スキーマ]のドキュメントも用意されています。
+本質的に、Vulkan は適合するハードウェアの実装が従う link:https://www.khronos.org/registry/vulkan/#apispecs[API 仕様]です。公開されている仕様は、Vulkan Specification リポジトリの公式公開コピーの link:https://github.com/KhronosGroup/Vulkan-Docs[Vulkan-Docs] にある link:https://github.com/KhronosGroup/Vulkan-Docs/blob/main/xml/vk.xml[./xml/vk.xml] Vulkan Registry ファイルから生成されています。また、link:https://www.khronos.org/registry/vulkan/specs/latest/registry.html[XML スキーマ]のドキュメントも用意されています。
 
 Khronos Group は、Vulkan Specification とともに、link:https://www.khronos.org/registry/vulkan/#apiregistry[API Registry] から生成された http://www.open-std.org/jtc1/sc22/wg14/www/standards[C99] link:https://github.com/KhronosGroup/Vulkan-Headers/tree/main/include/vulkan[ヘッダファイル]を公開しており、Vulkan API のインターフェイスに使用することができます。
 

--- a/lang/jp/chapters/what_vulkan_can_do.adoc
+++ b/lang/jp/chapters/what_vulkan_can_do.adoc
@@ -37,16 +37,16 @@ GPGPU と呼ばれる新しいプログラミングスタイルを用いて、GP
 レイトレーシングとは光の物理的な振る舞いをシミュレートするというコンセプトに基づいた、ラスタライズとは別のレンダリング技術です。
 
 レイトレーシングのクロスベンダー API サポートは、Vulkan の1.2.162仕様で拡張機能として追加されました。
-主な拡張機能は link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`]、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_ray_query[`VK_KHR_ray_query`]、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`] です。
+主な拡張機能は link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`]、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_ray_query[`VK_KHR_ray_query`]、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`] です。
 
 [NOTE]
 ====
-レイトレーシングの実装を公開している古い link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_NV_ray_tracing[NVIDIA ベンダー拡張機能]もあります。この拡張機能はクロスベンダー拡張機能よりも前から存在しました。新規に開発する場合は、新しい KHR 拡張機能を使用することをお勧めします。
+レイトレーシングの実装を公開している古い link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VK_NV_ray_tracing[NVIDIA ベンダー拡張機能]もあります。この拡張機能はクロスベンダー拡張機能よりも前から存在しました。新規に開発する場合は、新しい KHR 拡張機能を使用することをお勧めします。
 ====
 
 == ビデオ
 
-link:https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-decode[Vulkan Video拡張機能]により、開発者はハードウェアアクセラレーションによるビデオデコード機能をリアルタイムで使用することができます。この機能は、link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_queue.html[VK_KHR_video_queue]、link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_queue.html[VK_KHR_video_decode_queue]、link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_h264.html[VK_KHR_video_decode_h264]、link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_h265.html[VK_KHR_video_decode_h265] 拡張機能を通じて公開されています。
+link:https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-decode[Vulkan Video拡張機能]により、開発者はハードウェアアクセラレーションによるビデオデコード機能をリアルタイムで使用することができます。この機能は、link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_queue.html[VK_KHR_video_queue]、link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_queue.html[VK_KHR_video_decode_queue]、link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_h264.html[VK_KHR_video_decode_h264]、link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_h265.html[VK_KHR_video_decode_h265] 拡張機能を通じて公開されています。
 
 Vulkan Video は Vulkan の理念に基づき、ビデオ処理のスケジューリング、同期、メモリ使用などを、柔軟かつきめ細かくアプリケーションに提供します。
 

--- a/lang/jp/chapters/wsi.adoc
+++ b/lang/jp/chapters/wsi.adoc
@@ -6,7 +6,7 @@ ifndef::chapters[:chapters:]
 [[wsi]]
 = Window System Integration (WSI)
 
-Vulkan API は結果を表示しなくても使用できるため、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#wsi[オプションの Vulkan 拡張機能] を使用することで WSI を提供しています。ほとんどの実装には WSI の対応が含まれています。WSI の設計は、各プラットフォームのウィンドウメカニズムをコアの Vulkan API から抽象化するために作成されました。
+Vulkan API は結果を表示しなくても使用できるため、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#wsi[オプションの Vulkan 拡張機能] を使用することで WSI を提供しています。ほとんどの実装には WSI の対応が含まれています。WSI の設計は、各プラットフォームのウィンドウメカニズムをコアの Vulkan API から抽象化するために作成されました。
 
 image::../../../chapters/images/wsi_setup.png[wsi_setup]
 
@@ -16,25 +16,25 @@ image::../../../chapters/images/wsi_setup.png[wsi_setup]
 
 Vulkan Surface をサポートする各プラットフォームは、それぞれのプラットフォーム固有の API から `VkSurfaceKHR` オブジェクトを作成する独自の方法を持っています。
 
-  * Android - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
-  * DirectFB - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
-  * Fuchsia - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
-  * iOS - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
-  * macOS - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
-  * Metal - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]
-  * VI - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateViSurfaceNN[vkCreateViSurfaceNN]
-  * Wayland - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkWaylandSurfaceCreateInfoKHR[vkWaylandSurfaceCreateInfoKHR]
-  * QNX - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateScreenSurfaceQNX.html[vkCreateScreenSurfaceQNX]
-  * Windows - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateWin32SurfaceKHR[vkCreateWin32SurfaceKHR]
-  * XCB - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateXcbSurfaceKHR[vkCreateXcbSurfaceKHR]
-  * Xlib - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateXlibSurfaceKHR[vkCreateXlibSurfaceKHR]
-  * Direct-to-Display - link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDisplayPlaneSurfaceKHR[vkCreateDisplayPlaneSurfaceKHR]
+  * Android - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
+  * DirectFB - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
+  * Fuchsia - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
+  * iOS - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
+  * macOS - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
+  * Metal - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]
+  * VI - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateViSurfaceNN[vkCreateViSurfaceNN]
+  * Wayland - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkWaylandSurfaceCreateInfoKHR[vkWaylandSurfaceCreateInfoKHR]
+  * QNX - link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/vkCreateScreenSurfaceQNX.html[vkCreateScreenSurfaceQNX]
+  * Windows - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateWin32SurfaceKHR[vkCreateWin32SurfaceKHR]
+  * XCB - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateXcbSurfaceKHR[vkCreateXcbSurfaceKHR]
+  * Xlib - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateXlibSurfaceKHR[vkCreateXlibSurfaceKHR]
+  * Direct-to-Display - link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkCreateDisplayPlaneSurfaceKHR[vkCreateDisplayPlaneSurfaceKHR]
 
-`VkSurfaceKHR` には、さまざまなlink:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfaceCapabilitiesKHR[機能]、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfaceFormatsKHR[フォーマット]、link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfacePresentModesKHR[表示モード]があり、それらをクエリすることができます。
+`VkSurfaceKHR` には、さまざまなlink:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfaceCapabilitiesKHR[機能]、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfaceFormatsKHR[フォーマット]、link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfacePresentModesKHR[表示モード]があり、それらをクエリすることができます。
 
 == スワップチェーン
 
-`VkSwapchainKHR` オブジェクトは、`VkImage` オブジェクトの配列を通じてレンダリング結果をサーフェスに表示する機能を提供します。スワップチェーンのさまざまな link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VkPresentModeKHR[表示モード]は、表示エンジンがどのように実装されるかを決定します。
+`VkSwapchainKHR` オブジェクトは、`VkImage` オブジェクトの配列を通じてレンダリング結果をサーフェスに表示する機能を提供します。スワップチェーンのさまざまな link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#VkPresentModeKHR[表示モード]は、表示エンジンがどのように実装されるかを決定します。
 
 image::../../../chapters/images/wsi_engine.png[wsi_engine]
 
@@ -44,4 +44,4 @@ Khronos のlink:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples
 
 モバイル機器は回転させることができるため、アプリケーションウィンドウの論理的な向きとディスプレイの物理的な向きが一致しないことがあります。アプリケーションは、`portrait` と `landscape` の2つのモードで動作できる必要があります。この2つのモードの違いは、単に解像度の変更だけで簡単に説明できます。しかし、ディスプレイサブシステムの中には、常にディスプレイパネルの「ネイティブ」（または「物理的」）な向きで動作するものがあります。デバイスが回転しているので、望ましい効果を得るためには、アプリケーション出力も回転させる必要があります。
 
-Android などのモバイルプラットフォームで Vulkan を最大限に活用するためには、回転の前にすることを実装することが必須となります。スワップチェーンの作成時に方向を指定してサーフェスの回転を処理する方法については、link:https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html?m=1[Google のブログ記事]に詳細が記載されており、link:https://github.com/google/vulkan-pre-rotation-demo[スタンドアロンのサンプル]も用意されています。また、link:https://github.com/KhronosGroup/Vulkan-Samples[Vulkan-Samples] には、回転の前にすることがなぜ問題になるのか、またシェーダで解決する方法を示すlink:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[実行サンプル]がlink:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[公開されています]。Adreno GPU を搭載したデバイスを使用している場合、クアルコムは link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_QCOM_render_pass_transform.html[VK_QCOM_render_pass_transform] 拡張機能を使用して回転の前にすることを実装することを提案しています。
+Android などのモバイルプラットフォームで Vulkan を最大限に活用するためには、回転の前にすることを実装することが必須となります。スワップチェーンの作成時に方向を指定してサーフェスの回転を処理する方法については、link:https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html?m=1[Google のブログ記事]に詳細が記載されており、link:https://github.com/google/vulkan-pre-rotation-demo[スタンドアロンのサンプル]も用意されています。また、link:https://github.com/KhronosGroup/Vulkan-Samples[Vulkan-Samples] には、回転の前にすることがなぜ問題になるのか、またシェーダで解決する方法を示すlink:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[実行サンプル]がlink:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[公開されています]。Adreno GPU を搭載したデバイスを使用している場合、クアルコムは link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VK_QCOM_render_pass_transform.html[VK_QCOM_render_pass_transform] 拡張機能を使用して回転の前にすることを実装することを提案しています。

--- a/lang/kor/chapters/atomics.adoc
+++ b/lang/kor/chapters/atomics.adoc
@@ -46,10 +46,10 @@ GLSL과 SPIR-V 모두 아토믹 카운터 사용을 지원하지만, Vulkan은 `
 
 현재 아토믹의 추가 지원을 공개하고 있는 확장 기능은 다음과 같습니다.
 
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_atomic_int64.html[VK_KHR_shader_atomic_int64]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_image_atomic_int64.html[VK_EXT_shader_image_atomic_int64]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float.html[VK_EXT_shader_atomic_float]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_atomic_float2.html[VK_EXT_shader_atomic_float2]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_shader_atomic_int64.html[VK_KHR_shader_atomic_int64]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_image_atomic_int64.html[VK_EXT_shader_image_atomic_int64]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_atomic_float.html[VK_EXT_shader_atomic_float]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_atomic_float2.html[VK_EXT_shader_atomic_float2]
 
 아래에서 각각에 대해 자세히 설명합니다.
 

--- a/lang/kor/chapters/depth.adoc
+++ b/lang/kor/chapters/depth.adoc
@@ -127,7 +127,7 @@ destinationStage = VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR | VK_PIPELIN
 [[pre-rasterization]]
 == 래스터화 전(Pre-rasterization)
 
-그래픽스 파이프라인에는 래스터화할 프리미티브를 생성하는 일련의  link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[래스터화 전 쉐이더 단계]가 있습니다. 래스터화 단계에 도달하기 전에 래스터화 전 마지막 단계의 최종 `vec4` 위치(`gl_Position`)는  link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vertexpostproc[고정 함수 정점 포스트 프로세싱]을 통해 실행됩니다.
+그래픽스 파이프라인에는 래스터화할 프리미티브를 생성하는 일련의  link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[래스터화 전 쉐이더 단계]가 있습니다. 래스터화 단계에 도달하기 전에 래스터화 전 마지막 단계의 최종 `vec4` 위치(`gl_Position`)는  link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vertexpostproc[고정 함수 정점 포스트 프로세싱]을 통해 실행됩니다.
 
 다음은 래스터화 전에 수행되는 다양한 좌표명과 연산에 대한 개괄적인 개요입니다.
 
@@ -155,7 +155,7 @@ image::../../../chapters/images/depth_coordinates_flow.png[depth_coordinates_flo
 [[user-defined-clipping-and-culling]]
 ==== 사용자 정의 클리핑 및 컬링(User defined clipping and culling)
 
-`ClipDistance` 및 `CullDistance` 내장 배열을 사용하여 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[래스터화 전 쉐이더 단계] 에서 link:https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#User-defined_clipping[사용자 정의 클리핑 및 컬링]을 설정할 수 있습니다.
+`ClipDistance` 및 `CullDistance` 내장 배열을 사용하여 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipeline-graphics-subsets-pre-rasterization[래스터화 전 쉐이더 단계] 에서 link:https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#User-defined_clipping[사용자 정의 클리핑 및 컬링]을 설정할 수 있습니다.
 
 마지막 래스터화 전 쉐이더 단계에서 이 값은 프리미티브 전체에 걸쳐 선형 보간되며 보간된 거리가 `0` 보다 작은 프리미티브 부분은 클립 볼퓸 외부로 간주됩니다. 이후 프래그먼트 쉐이더에서 `ClipDistance` 또는 `CullDistance` 를 사용하는 경우, 이 선형 보간된 값이 포함됩니다.
 
@@ -176,7 +176,7 @@ OpenGL에서는 `view volume` 는 다음과 같이 표현됩니다.
 
 `[-1, 1]` 의 바깥쪽에 있는 것은 클립됩니다.
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_depth_clip_control.html[VK_EXT_depth_clip_control] 확장을 추가하여 Vulkan 위에 OpenGL을 효율적으로 레이어링할 수 있습니다. `VkPipeline` 을 생성할 때, `VkPipelineViewportDepthClipControlCreateInfoEXT::negativeOneToOne` 을 `VK_TRUE` 로 설정하면 OpenGL `[-1, 1]` 뷰 볼륨을 사용할 수 있습니다.
+link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_depth_clip_control.html[VK_EXT_depth_clip_control] 확장을 추가하여 Vulkan 위에 OpenGL을 효율적으로 레이어링할 수 있습니다. `VkPipeline` 을 생성할 때, `VkPipelineViewportDepthClipControlCreateInfoEXT::negativeOneToOne` 을 `VK_TRUE` 로 설정하면 OpenGL `[-1, 1]` 뷰 볼륨을 사용할 수 있습니다.
 
 `VK_EXT_depth_clip_control` 을 사용할 수 없는 경우, link:https://github.com/KhronosGroup/Vulkan-Docs/issues/1054#issuecomment-547202276[현재 회피책]을 사용하여 래스터화 전 쉐이더에서 변환을 수행합니다.
 
@@ -195,7 +195,7 @@ position.z = (position.z + position.w) * 0.5;
 
 [NOTE]
 ====
-뷰포트 값은 `VK_DYNAMIC_STATE_VIEWPORT` 또는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] 의 `VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
+뷰포트 값은 `VK_DYNAMIC_STATE_VIEWPORT` 또는 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state] 의 `VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
 ====
 
 [[depth-range]]
@@ -208,7 +208,7 @@ position.z = (position.z + position.w) * 0.5;
 이름과 상관없이 `minDepth` 는 `maxDepth` 보다 작든, 같든, 크든 문제없습니다.
 ====
 
-`minDepth` 와 `maxDepth` 는 `0.0` 에서 `1.0` 사이로만 설정하도록 제한되어 있습니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_depth_range_unrestricted.html[VK_EXT_depth_range_unrestricted]를 활성화하면 이 제한이 사라집니다.
+`minDepth` 와 `maxDepth` 는 `0.0` 에서 `1.0` 사이로만 설정하도록 제한되어 있습니다. link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_depth_range_unrestricted.html[VK_EXT_depth_range_unrestricted]를 활성화하면 이 제한이 사라집니다.
 
 프레임버퍼 깊이 좌표 `Zf` 는 다음과 같이 표시됩니다:
 
@@ -229,7 +229,7 @@ Zf = Pz * Zd + Oz
 
 다각형의 래스터화에 의해 생성된 모든 프래그먼트의 깊이 값은 해당 다각형에 대해 계산된 단일 값으로 오프셋할 수 있습니다. 그리기 시점에 `VkPipelineRasterizationStateCreateInfo::depthBiasEnable` 이 `VK_FALSE` 인 경우 깊이 바이어스가 적용되지 않습니다.
 
-`VkPipelineRasterizationStateCreateInfo` 의 `depthBiasConstantFactor`, `depthBiasClamp`, `depthBiasSlopeFactor` 를 사용하여 깊이 바이어스 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-depthbias[를 계산할 수 있습니다].
+`VkPipelineRasterizationStateCreateInfo` 의 `depthBiasConstantFactor`, `depthBiasClamp`, `depthBiasSlopeFactor` 를 사용하여 깊이 바이어스 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-depthbias[를 계산할 수 있습니다].
 
 [NOTE]
 ====
@@ -238,7 +238,7 @@ Zf = Pz * Zd + Oz
 
 [NOTE]
 ====
-깊이 바이어스 값은 `VK_DYNAMIC_STATE_DEPTH_BIAS` 또는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state2.html[VK_EXT_extended_dynamic_state2]의 `VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
+깊이 바이어스 값은 `VK_DYNAMIC_STATE_DEPTH_BIAS` 또는 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state2.html[VK_EXT_extended_dynamic_state2]의 `VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
 ====
 
 [[post-rasterization]]
@@ -284,9 +284,9 @@ layout(depth_unchanged) out float gl_FragDepth;
 [[per-sample-processing-and-coverage-mask]]
 === 샘플별 처리 및 커버리지 마스크(Per-sample processing and coverage mask)
 
-다음 래스터화-후 작업은 "샘플별" 작업으로 이루어집니다. 즉, 컬러 첨부가 있는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fragops-covg[멀티샘플링]을 수행할 때, 사용되는 모든 "깊이 버퍼" `VkImage` 도 동일한 `VkSampleCountFlagBits` 값으로 생성되어 있어야 합니다.
+다음 래스터화-후 작업은 "샘플별" 작업으로 이루어집니다. 즉, 컬러 첨부가 있는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fragops-covg[멀티샘플링]을 수행할 때, 사용되는 모든 "깊이 버퍼" `VkImage` 도 동일한 `VkSampleCountFlagBits` 값으로 생성되어 있어야 합니다.
 
-각 프래그먼트에는 해당 프래그먼트 내의 샘플이 해당 프래그먼트를 생성한 프리미티브의 영역 내에 있는 것으로 판단되는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[커버리지 마스크]가 설정되어 있습니다. 프래그먼트 조작 결과 커버리지 마스크의 모든 비트가 `0` 이면 프래그먼트는 파기됩니다.
+각 프래그먼트에는 해당 프래그먼트 내의 샘플이 해당 프래그먼트를 생성한 프리미티브의 영역 내에 있는 것으로 판단되는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[커버리지 마스크]가 설정되어 있습니다. 프래그먼트 조작 결과 커버리지 마스크의 모든 비트가 `0` 이면 프래그먼트는 파기됩니다.
 
 [[resolving-depth-buffer]]
 ==== 깊이 버퍼 처리(Resolving depth buffer)
@@ -301,11 +301,11 @@ Vulkan에서는 xref:{chapters}extensions/cleanup.adoc#vk_khr_depth_stencil_reso
 `VkPhysicalDeviceFeatures::depthBounds` 기능이 지원되어야 합니다.
 ====
 
-`VkPipelineDepthStencilStateCreateInfo::depthBoundsTestEnable` 을 사용하면, 깊이 첨부의 각 `Za` 를 가져와 `VkPipelineDepthStencilStateCreateInfo::minDepthBounds` 및 `VkPipelineDepthStencilStateCreateInfo::maxDepthBounds` 에 의해 설정된 범위 내에 있는지 확인합니다. 값이 경계 내에 있지 않은 경우, link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[커버리지 마스크]는 0으로 설정됩니다.
+`VkPipelineDepthStencilStateCreateInfo::depthBoundsTestEnable` 을 사용하면, 깊이 첨부의 각 `Za` 를 가져와 `VkPipelineDepthStencilStateCreateInfo::minDepthBounds` 및 `VkPipelineDepthStencilStateCreateInfo::maxDepthBounds` 에 의해 설정된 범위 내에 있는지 확인합니다. 값이 경계 내에 있지 않은 경우, link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[커버리지 마스크]는 0으로 설정됩니다.
 
 [NOTE]
 ====
-깊이 경계 값은 `VK_DYNAMIC_STATE_DEPTH_BOUNDS` 또는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state]의 `VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
+깊이 경계 값은 `VK_DYNAMIC_STATE_DEPTH_BOUNDS` 또는 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state]의 `VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
 ====
 
 [[depth-test]]
@@ -330,17 +330,17 @@ image::../../../chapters/images/depth_test.png[depth_test]
 
 [NOTE]
 ====
-`depthTestEnable` 및 `depthCompareOp` 값은 `VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT` 와 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state]의 `VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
+`depthTestEnable` 및 `depthCompareOp` 값은 `VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT` 와 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state]의 `VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
 ====
 
 [[depth-buffer-writes]]
 ==== 깊이 버퍼 쓰기(Depth Buffer Writes)
 
-깊이 테스트에 통과하더라도 `VkPipelineDepthStencilStateCreateInfo::depthWriteEnable` 이 `VK_FALSE` 로 설정되어 있으면, 깊이 첨부에 값이 써지지 않습니다. 그 주된 이유는 깊이 테스트 자체가 특정 렌더링 기법에 사용될 수 있는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-multisampling-coverage-mask[커버리지 마스크]를 설정하기 위해서입니다.
+깊이 테스트에 통과하더라도 `VkPipelineDepthStencilStateCreateInfo::depthWriteEnable` 이 `VK_FALSE` 로 설정되어 있으면, 깊이 첨부에 값이 써지지 않습니다. 그 주된 이유는 깊이 테스트 자체가 특정 렌더링 기법에 사용될 수 있는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-multisampling-coverage-mask[커버리지 마스크]를 설정하기 위해서입니다.
 
 [NOTE]
 ====
-`depthWriteEnable` 값은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state]의 `VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
+`depthWriteEnable` 값은 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html[VK_EXT_extended_dynamic_state]의 `VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT` 를 사용하여 xref:{chapters}dynamic_state.adoc[동적으로] 설정할 수 있습니다.
 ====
 
 [[depth-clamping]]

--- a/lang/kor/chapters/descriptor_dynamic_offset.adoc
+++ b/lang/kor/chapters/descriptor_dynamic_offset.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[descriptor-dynamic-offset]]
 = 디스크립터 동적 오프셋(Descriptor Dynamic Offset)
 
-Vulkan은 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#descriptorsets-binding-dynamicoffsets[사양으로 정의된 대로] 바인드 시 오프셋을 조정할 수 있는 두 종류의 디스크립터를 제공합니다.
+Vulkan은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-binding-dynamicoffsets[사양으로 정의된 대로] 바인드 시 오프셋을 조정할 수 있는 두 종류의 디스크립터를 제공합니다.
 
 * 동적 유니폼 버퍼(`VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC`)
 * 동적 스토리지 버퍼(`VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC`)

--- a/lang/kor/chapters/dynamic_state.adoc
+++ b/lang/kor/chapters/dynamic_state.adoc
@@ -9,7 +9,7 @@ ifndef::images[:images: images/]
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-dynamic-state[Vulkan Spec chapter]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipelines-dynamic-state[Vulkan Spec chapter]
 ====
 
 == Overview
@@ -38,7 +38,7 @@ vkCmdDraw();
 vkEndCommandBuffer();
 ----
 
-`VkPipeline` 가 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-dynamic-state[동적인 상태]를 사용하고 있는 경우, 일부 파이프라인 정보를 작성할 때 생략하는 대신 커맨드 버퍼를 기록하는 동안 설정할 수 있습니다. 새로운 로직 흐름은 다음과 같습니다:
+`VkPipeline` 가 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipelines-dynamic-state[동적인 상태]를 사용하고 있는 경우, 일부 파이프라인 정보를 작성할 때 생략하는 대신 커맨드 버퍼를 기록하는 동안 설정할 수 있습니다. 새로운 로직 흐름은 다음과 같습니다:
 
 [source,cpp]
 ----
@@ -87,7 +87,7 @@ Vulkan은 대부분의 도구가 그렇듯이 하나의 정답이 있는 것은 
 [[states-that-are-dynamic]]
 == 동적인 상태란
 
-동적으로 할 수 있는 상태 목록은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDynamicState[VkDynamicState]에 있습니다.
+동적으로 할 수 있는 상태 목록은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDynamicState[VkDynamicState]에 있습니다.
 
 The `VK_EXT_extended_dynamic_state`, `VK_EXT_extended_dynamic_state2`, `VK_EXT_extended_dynamic_state3`, `VK_EXT_vertex_input_dynamic_state`, `VK_EXT_attachment_feedback_loop_dynamic_state` and `VK_EXT_color_write_enable`
 확장 기능은 컴파일하고 바인드하는 파이프라인 상태 객체의 수를 줄이기 위해 추가되었습니다.

--- a/lang/kor/chapters/enabling_extensions.adoc
+++ b/lang/kor/chapters/enabling_extensions.adoc
@@ -19,7 +19,7 @@ image::../../../chapters/images/enabling_extensions_instance_extension.png[enabl
 
 == 지원 확인
 
-애플리케이션은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-extensions[물리적 장치에 대한 쿼리]를 통해 먼저 `vkEnumerateInstanceExtensionProperties` 또는 `vkEnumerateDeviceExtensionProperties` 로 확장 기능이 **지원**되는지 확인할 수 있습니다.
+애플리케이션은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-extensions[물리적 장치에 대한 쿼리]를 통해 먼저 `vkEnumerateInstanceExtensionProperties` 또는 `vkEnumerateDeviceExtensionProperties` 로 확장 기능이 **지원**되는지 확인할 수 있습니다.
 
 [source,cpp]
 ----
@@ -78,7 +78,7 @@ This means after enabling the extension, an application will still need to xref:
 
 == 승격 과정
 
-xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan의 마니어 버전이 출시되면], 일부 확장 기능이 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[사양서에 정의된 대로 승격]됩니다. 승격의 목적은 Vulkan을 사용하는 여러 단체에서 광범위하게 지원하기로 결정한 확장 기능을 Vulkan 핵심 사양에 포함시키는 것입니다. Vulkan 버전에 대한 자세한 내용은 xref:{chapters}versions.adoc#versions[버전 챕터]에서 확인할 수 있습니다.
+xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan의 마니어 버전이 출시되면], 일부 확장 기능이 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[사양서에 정의된 대로 승격]됩니다. 승격의 목적은 Vulkan을 사용하는 여러 단체에서 광범위하게 지원하기로 결정한 확장 기능을 Vulkan 핵심 사양에 포함시키는 것입니다. Vulkan 버전에 대한 자세한 내용은 xref:{chapters}versions.adoc#versions[버전 챕터]에서 확인할 수 있습니다.
 
 예를 들어 대부분의 다른 확장 기능에 사용되고 있는 `VK_KHR_get_physical_device_properties2` 와 같은 것이 있습니다. Vulkan 1.0에서는 애플리케이션이 `vkGetPhysicalDeviceFeatures2KHR` 과 같은 함수를 호출하기 전에 `VK_KHR_get_physical_device_properties2` 의 지원 여부를 쿼리해야합니다. Vulakn 1.1부터는 `vkGetPhysicalDeviceFeatures2` 함수가 지원되도록 보장됩니다.
 
@@ -86,9 +86,9 @@ xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan의 마�
 
 === 승격에 따른 행동 변화
 
-승격되는 **일부** 확장 기능에는 미묘한 차이가 있음을 인식하는 것이 중요합니다. 승격에는 확장 기능의 "`Feature advertisement/enablement`" 와 같은 작은 변경점이 포함될 수 있다고 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[사양서에 설명되어 있습니다]. `VK_KHR_8bit_storage` 를 사용한 사례가 이 작은 차이점을 가장 잘 설명할 수 있습니다.
+승격되는 **일부** 확장 기능에는 미묘한 차이가 있음을 인식하는 것이 중요합니다. 승격에는 확장 기능의 "`Feature advertisement/enablement`" 와 같은 작은 변경점이 포함될 수 있다고 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[사양서에 설명되어 있습니다]. `VK_KHR_8bit_storage` 를 사용한 사례가 이 작은 차이점을 가장 잘 설명할 수 있습니다.
 
- Vulkan 1.2의 `VK_KHR_8bit_storage` 에 대한 변경 사항은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_differences_relative_to_vk_khr_8bit_storage[Vulkan 사양서에 설명되어 있습니다]:
+ Vulkan 1.2의 `VK_KHR_8bit_storage` 에 대한 변경 사항은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_differences_relative_to_vk_khr_8bit_storage[Vulkan 사양서에 설명되어 있습니다]:
 
 ____
 VK_KHR_8bit_storage 확장 기능이 지원되지 않는 경우 쉐이더 모듈에서 SPIR-V StorageBuffer8BitAccess 기능에 대한 지원은 선택 사항입니다.
@@ -99,4 +99,4 @@ ____
   * `vkEnumerateDeviceExtensionProperties` 에서 `VK_KHR_8bit_storage` 가 발견된 경우에는 `storageBuffer8BitAccess` 기능이 지원되는 것이 **보장**됩니다.
   * `vkEnumerateDeviceExtensionProperties` 에서 `VK_KHR_8bit_storage` 를 **찾을 수 없는** 경우에는 `storageBuffer8BitAccess` 기능이 지원되고 **있을 수도** 있으며, `VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess` 를 쿼리하여 확인할 수 있습니다.
 
-승격된 확장 기능의 모든 기능 변경 사항 목록은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions[버전 부록]에서 확인할 수 있습니다.
+승격된 확장 기능의 모든 기능 변경 사항 목록은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions[버전 부록]에서 확인할 수 있습니다.

--- a/lang/kor/chapters/enabling_features.adoc
+++ b/lang/kor/chapters/enabling_features.adoc
@@ -14,17 +14,17 @@ ifndef::images[:images: images/]
 Vulkan의 모든 기능은 다음 3가지 섹션으로 분류될 수 있습니다
 
   1. 핵심 1.0 기능
-  ** 다음은 Vulkan의 초기 1.0 릴리즈부터 제공된 기능 모음입니다. 기능 목록은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceFeatures[VkPhysicalDeviceFeatures]에 기재되어 있습니다.
+  ** 다음은 Vulkan의 초기 1.0 릴리즈부터 제공된 기능 모음입니다. 기능 목록은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceFeatures[VkPhysicalDeviceFeatures]에 기재되어 있습니다.
   2. 미래 핵심 버전의 기능
   ** Vulkan 1.1 이상 부터는 Vulkan의 핵심 버전에 몇 가지 새로운 기능이 추가되었습니다. 이전 버전과의 호환성을 유지하기 위해 `VkPhysicalDeviceFeatures` 의 크기를 유지하기 위해 기능 그룹을 보관하는 새로운 구조체를 만들었습니다.
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceVulkan11Features[VkPhysicalDeviceVulkan11Features]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPhysicalDeviceVulkan12Features[VkPhysicalDeviceVulkan12Features]
+  ** link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceVulkan11Features[VkPhysicalDeviceVulkan11Features]
+  ** link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceVulkan12Features[VkPhysicalDeviceVulkan12Features]
   3. 확장 기능
   ** 확장 기능에는 그 확장 기능의 어떤 부분을 활성화하기 위한 기능이 포함되어 있을 수 있습니다. 이러한 기능은 모두 `VkPhysicalDevice[ExtensionName]Features` 로 레이블이 붙어 있으므로 쉽게 찾을 수 있습니다.
 
 == 기능 활성화하는 방법
 
-모든 기능은 `VkDevice` 생성할 때, link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDeviceCreateInfo[VkDeviceCreateInfo] 구조체 내에서 활성화해야 합니다.
+모든 기능은 `VkDevice` 생성할 때, link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDeviceCreateInfo[VkDeviceCreateInfo] 구조체 내에서 활성화해야 합니다.
 
 [NOTE]
 ====

--- a/lang/kor/chapters/extensions/VK_KHR_shader_subgroup_uniform_control_flow.adoc
+++ b/lang/kor/chapters/extensions/VK_KHR_shader_subgroup_uniform_control_flow.adoc
@@ -9,7 +9,7 @@ ifndef::images[:images: ../images/]
 
 == 개요
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_subgroup_uniform_control_flow.html[VK_KHR_shader_subgroup_uniform_control_flow]는 쉐이더에서 호출의 재수렴을 더욱 강력하게 보장합니다.+
+link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_shader_subgroup_uniform_control_flow.html[VK_KHR_shader_subgroup_uniform_control_flow]는 쉐이더에서 호출의 재수렴을 더욱 강력하게 보장합니다.+
 확장이 지원되는 경우 쉐이더를 수정하여 더 강력한 보장을 제공하는 새로운 속성을 포함할 수 있습니다(link:https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_subgroup_uniform_control_flow.txt[GL_EXT_subgroup_uniform_control_flow] 참조).+
 이 속성은 서브그룹 작업을 지원하는 쉐이더 스테이지에만 적용할 수 있습니다.
 (`VkPhysicalDeviceSubgroupProperties::supportedStages` 또는

--- a/lang/kor/chapters/extensions/cleanup.adoc
+++ b/lang/kor/chapters/extensions/cleanup.adoc
@@ -21,7 +21,7 @@ ifndef::images[:images: ../images/]
 Vulkan 1.2에서 코어로 승격됨
 ====
 
-이 확장 기능은 각 구현에 대한 쿼리에 더 많은 정보를 추가합니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDriverId[VkDriverId]는 구현에 대해 등록된 제조사의 ID입니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkConformanceVersion[VkConformanceVersion]은 구현이 xref:{chapters}vulkan_cts.adoc#vulkan-cts[Vulkan 적합성 테스트 제품군(CTS)]을 통과한 버전을 표시합니다.
+이 확장 기능은 각 구현에 대한 쿼리에 더 많은 정보를 추가합니다. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDriverId[VkDriverId]는 구현에 대해 등록된 제조사의 ID입니다. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkConformanceVersion[VkConformanceVersion]은 구현이 xref:{chapters}vulkan_cts.adoc#vulkan-cts[Vulkan 적합성 테스트 제품군(CTS)]을 통과한 버전을 표시합니다.
 
 [[VK_EXT_host_query_reset]]
 == VK_EXT_host_query_reset
@@ -129,10 +129,10 @@ Vulkan 1.3에서 코어로 승격됨
 
 현재 4개의 유지보수 확장 기능이 있습니다. 처음 3개는 Vulkan 1.1에 코어로 번들되어 제공되었습니다. 각 확장 기능에 대한 자세한 내용은 확장 부록 페이지에서 잘 정의되어 있습니다.
 
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance1[VK_KHR_maintenance1] - core in Vulkan 1.1
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance2[VK_KHR_maintenance2] - core in Vulkan 1.1
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance3[VK_KHR_maintenance3] - core in Vulkan 1.1
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_maintenance4[VK_KHR_maintenance4] - core in Vulkan 1.3
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance1[VK_KHR_maintenance1] - core in Vulkan 1.1
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance2[VK_KHR_maintenance2] - core in Vulkan 1.1
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance3[VK_KHR_maintenance3] - core in Vulkan 1.1
+  * link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_maintenance4[VK_KHR_maintenance4] - core in Vulkan 1.3
 
 [[pnext-expansions]]
 == pNext 확장 기능
@@ -240,7 +240,7 @@ void vkBindImageMemory(VkDevice device,
 }
 
 void vkBindImageMemory2(VkDevice device,
-                        uint32_t bindInfoCount, 
+                        uint32_t bindInfoCount,
                         const VkBindImageMemoryInfo* pBindInfos)
 {
     for (uint32_t i = 0; i < bindInfoCount; i++) {

--- a/lang/kor/chapters/extensions/ray_tracing.adoc
+++ b/lang/kor/chapters/extensions/ray_tracing.adoc
@@ -9,11 +9,11 @@ ifndef::images[:images: ../images/]
 
 Vulkan API에서 레이 트레이싱을 지원하는 상호 연관된 5가지 확장 기능 세트를 제공합니다.
 
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_acceleration_structure.html[VK_KHR_acceleration_structure]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_ray_tracing_pipeline.html[VK_KHR_ray_tracing_pipeline]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_ray_query.html[VK_KHR_ray_query]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_pipeline_library.html[VK_KHR_pipeline_library]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_deferred_host_operations.html[VK_KHR_deferred_host_operations]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_acceleration_structure.html[VK_KHR_acceleration_structure]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_ray_tracing_pipeline.html[VK_KHR_ray_tracing_pipeline]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_ray_query.html[VK_KHR_ray_query]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_pipeline_library.html[VK_KHR_pipeline_library]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_deferred_host_operations.html[VK_KHR_deferred_host_operations]
 
 추가적으로 SPIR-V 및 GLSL 확장 기능도 쉐이더에 필요한 프로그래밍 가능한 기능을 제공합니다:
 

--- a/lang/kor/chapters/extensions/shader_features.adoc
+++ b/lang/kor/chapters/extensions/shader_features.adoc
@@ -170,7 +170,7 @@ Vulkan 1.2에서 코어로 승격됨
 link:https://www.khronos.org/blog/comparing-the-vulkan-spir-v-memory-model-to-cs/[Comparing the Vulkan SPIR-V memory model to C's]
 ====
 
-The link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#memory-model[Vulkan Memory Model]은 여러 쉐이더 호출에 의해 수행되는 동일한 메모리 위치에 대한 메모리 액세스를 동기화하는 방법이라고 공식적으로 정의하며, 이 확장 기능은 부울(boolean) 값을 공개하여 구현이 이를 지원할 수 있도록 합니다. 이는 Vulkan/SPIR-V를 대상으로 하는 많은 것들에서 애플리케이션이 최적화하려고 시도하는 메모리 전송 작업이 구현 간에 중단되지 않도록 하는 것이 중요하기 때문입니다.
+The link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#memory-model[Vulkan Memory Model]은 여러 쉐이더 호출에 의해 수행되는 동일한 메모리 위치에 대한 메모리 액세스를 동기화하는 방법이라고 공식적으로 정의하며, 이 확장 기능은 부울(boolean) 값을 공개하여 구현이 이를 지원할 수 있도록 합니다. 이는 Vulkan/SPIR-V를 대상으로 하는 많은 것들에서 애플리케이션이 최적화하려고 시도하는 메모리 전송 작업이 구현 간에 중단되지 않도록 하는 것이 중요하기 때문입니다.
 
 [[VK_EXT_shader_viewport_index_layer]]
 == VK_EXT_shader_viewport_index_layer

--- a/lang/kor/chapters/formats.adoc
+++ b/lang/kor/chapters/formats.adoc
@@ -7,20 +7,20 @@ ifndef::images[:images: images/]
 [[formats]]
 = 포맷(Formats)
 
-Vulkan 포맷은 메모리 배치 방식을 설명하는 데 사용됩니다. 이 장에서는 Vulkan의 다양한 형식에 대한 개괄적인(high-level) 개요와 형식 사용 방법에 대한 몇가지 로지스틱(logistical) 정보를 제공하는 것을 목표로 합니다. 모든 세부 사항은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#formats[Vulkan 사양서 포맷 챕터]와 link:https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.html[크로노스 그룹 데이터 포맷 사양]에 이미 잘 명시되어 있습니다.
+Vulkan 포맷은 메모리 배치 방식을 설명하는 데 사용됩니다. 이 장에서는 Vulkan의 다양한 형식에 대한 개괄적인(high-level) 개요와 형식 사용 방법에 대한 몇가지 로지스틱(logistical) 정보를 제공하는 것을 목표로 합니다. 모든 세부 사항은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats[Vulkan 사양서 포맷 챕터]와 link:https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.html[크로노스 그룹 데이터 포맷 사양]에 이미 잘 명시되어 있습니다.
 
-`VkFormat` 의 가장 일반적인 사용 사례는 `VkImage` 를 생성할 때입니다. `VkFormat`&#8203;은 잘 정의되어 있기 때문에 `VkBufferView` , xref:{chapters}vertex_input_data_processing.adoc#input-attribute-format[정점 입력 속성], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-image-formats[SPIR-V 이미지 포맷 매핑], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html[하위 단계 가속 구조(BLAS)에서 삼각형 지오메트리 생성], 기타 등등의 메모리 레이아웃을 설명할 때에도 사용됩니다.
+`VkFormat` 의 가장 일반적인 사용 사례는 `VkImage` 를 생성할 때입니다. `VkFormat`&#8203;은 잘 정의되어 있기 때문에 `VkBufferView` , xref:{chapters}vertex_input_data_processing.adoc#input-attribute-format[정점 입력 속성], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-image-formats[SPIR-V 이미지 포맷 매핑], link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html[하위 단계 가속 구조(BLAS)에서 삼각형 지오메트리 생성], 기타 등등의 메모리 레이아웃을 설명할 때에도 사용됩니다.
 
 [[feature-support]]
 == 기능 지원
 
-"포맷 지원"은 포맷당 단일 바이너리 값이 아니라 각 포맷에 대해 지원되는 기능을 설명하는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] 집합이 있다는 점을 이해하는 것이 중요합니다.
+"포맷 지원"은 포맷당 단일 바이너리 값이 아니라 각 포맷에 대해 지원되는 기능을 설명하는 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] 집합이 있다는 점을 이해하는 것이 중요합니다.
 
-지원되는 포맷은 구현에 따라 다를 수 있지만 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#features-required-format-support[최소한의 포맷 기능 세트는 보장됩니다]. 애플리케이션은 지원되는 포맷 속성을 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#formats-properties[쿼리(query)]할 수 있습니다.
+지원되는 포맷은 구현에 따라 다를 수 있지만 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-required-format-support[최소한의 포맷 기능 세트는 보장됩니다]. 애플리케이션은 지원되는 포맷 속성을 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats-properties[쿼리(query)]할 수 있습니다.
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_get_physical_device_properties2.html[VK_KHR_get_physical_device_properties2] 와 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_format_feature_flags2.html[VK_KHR_format_feature_flags2]는 모두 포맷 기능을 쿼리하기 위한 또 다른 방법을 공개합니다.
+link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_get_physical_device_properties2.html[VK_KHR_get_physical_device_properties2] 와 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_format_feature_flags2.html[VK_KHR_format_feature_flags2]는 모두 포맷 기능을 쿼리하기 위한 또 다른 방법을 공개합니다.
 ====
 
 === 포맷 기능 쿼리 예제
@@ -75,7 +75,7 @@ if ((formatProperties3.linearTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_
 
 == 포맷의 변형(Variations of Formats)
 
-포맷에는 다양한 변형이 있으며, 대부분은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_identification_of_formats[포맷 이름]으로 그룹화되어 있습니다. 이미지를 다루는 경우 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageAspectFlagBits.html[VkImageAspectFlagBits] 값은 클리어나 복사와 같은 작업을 위해 데이터의 어느 부분에 액세스하고 있는지를 나타내는 데 사용됩니다.
+포맷에는 다양한 변형이 있으며, 대부분은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_identification_of_formats[포맷 이름]으로 그룹화되어 있습니다. 이미지를 다루는 경우 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkImageAspectFlagBits.html[VkImageAspectFlagBits] 값은 클리어나 복사와 같은 작업을 위해 데이터의 어느 부분에 액세스하고 있는지를 나타내는 데 사용됩니다.
 
 === 색상(Color)
 
@@ -83,39 +83,39 @@ if ((formatProperties3.linearTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_
 
 === 깊이와 스텐실(Depth and Stencil)
 
-`D` 또는 `S` 성분을 가진 포맷. 이러한 포맷은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#formats-depth-stencil[불투명하다고 간주되며], 깊이/스텐실 이미지와의 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkBufferImageCopy[복사]에 관해 특별한 규칙이 있습니다.
+`D` 또는 `S` 성분을 가진 포맷. 이러한 포맷은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats-depth-stencil[불투명하다고 간주되며], 깊이/스텐실 이미지와의 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkBufferImageCopy[복사]에 관해 특별한 규칙이 있습니다.
 
 일부 포맷은 깊이와 스텐실 성분을 모두 가지고 있으며, `VK_IMAGE_ASPECT_DEPTH_BIT` 와 `VK_IMAGE_ASPECT_STENCIL_BIT` 로 각각 따로 접근할 수 있습니다.
 
 [NOTE]
 ====
-Vulkan 1.2에서 승격된 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_separate_depth_stencil_layouts.html[VK_KHR_separate_depth_stencil_layouts] 와 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_separate_stencil_usage.html[VK_EXT_separate_stencil_usage]를 사용하면 깊이와 스텐실 성분 간에 보다 세밀하게 제어할 수 있습니다.
+Vulkan 1.2에서 승격된 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_separate_depth_stencil_layouts.html[VK_KHR_separate_depth_stencil_layouts] 와 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_separate_stencil_usage.html[VK_EXT_separate_stencil_usage]를 사용하면 깊이와 스텐실 성분 간에 보다 세밀하게 제어할 수 있습니다.
 ====
 
 깊이 포맷에 대한 자세한 내용은 xref:{chapters}depth.adoc#depth-formats[깊이 챕터]에서도 확인할 수 있습니다.
 
 === 압축(Compressed)
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#compressed_image_formats[압축 이미지 포맷]은 한 영역 내에 여러 화소를 상호 의존적으로 인코딩하여 표현하는 포맷입니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#compressed_image_formats[압축 이미지 포맷]은 한 영역 내에 여러 화소를 상호 의존적으로 인코딩하여 표현하는 포맷입니다.
 
 .Vulkan 압축 이미지 포맷
 [options="header"]
 |===
 |포맷| 활성화 방법
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-bc[BC (Block-Compressed)] |`VkPhysicalDeviceFeatures::textureCompressionBC`
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-etc2[ETC2 and EAC] |`VkPhysicalDeviceFeatures::textureCompressionETC2`
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-astc[ASTC LDR] |`VkPhysicalDeviceFeatures::textureCompressionASTC_LDR`
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-astc[ASTC HDR] |link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_texture_compression_astc_hdr.html[VK_EXT_texture_compression_astc_hdr]
-|link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#appendix-compressedtex-pvrtc[PVRTC] | link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_IMG_format_pvrtc.html[VK_IMG_format_pvrtc]
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-bc[BC (Block-Compressed)] |`VkPhysicalDeviceFeatures::textureCompressionBC`
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-etc2[ETC2 and EAC] |`VkPhysicalDeviceFeatures::textureCompressionETC2`
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-astc[ASTC LDR] |`VkPhysicalDeviceFeatures::textureCompressionASTC_LDR`
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-astc[ASTC HDR] |link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_texture_compression_astc_hdr.html[VK_EXT_texture_compression_astc_hdr]
+|link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#appendix-compressedtex-pvrtc[PVRTC] | link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_IMG_format_pvrtc.html[VK_IMG_format_pvrtc]
 |===
 
 === 평면(Planar)
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_sampler_ycbcr_conversion.html[VK_KHR_sampler_ycbcr_conversion] 와 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_ycbcr_2plane_444_formats.html[VK_EXT_ycbcr_2plane_444_formats]은 xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc#multi-planar-formats[다중 평면 포맷]을 Vulakn에 추가하였습니다. `VK_IMAGE_ASPECT_PLANE_0_BIT`, `VK_IMAGE_ASPECT_PLANE_1_BIT`, `VK_IMAGE_ASPECT_PLANE_2_BIT` 로 각 평면에 개별적으로 접근할 수 있습니다.
+link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_sampler_ycbcr_conversion.html[VK_KHR_sampler_ycbcr_conversion] 와 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_ycbcr_2plane_444_formats.html[VK_EXT_ycbcr_2plane_444_formats]은 xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc#multi-planar-formats[다중 평면 포맷]을 Vulakn에 추가하였습니다. `VK_IMAGE_ASPECT_PLANE_0_BIT`, `VK_IMAGE_ASPECT_PLANE_1_BIT`, `VK_IMAGE_ASPECT_PLANE_2_BIT` 로 각 평면에 개별적으로 접근할 수 있습니다.
 
 === 팩(Packed)
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#formats-packed[패킹된 포맷]은 주소 정렬을 위한 것입니다. 예를 들어, `VK_FORMAT_A8B8G8R8_UNORM_PACK32` 와 `VK_FORMAT_R8G8B8A8_UNORM` 은 매우 비슷해 보이지만 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex-input-extraction[사양서의 정점 입력 추출 섹션]의 공식을 사용하면 달라집니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats-packed[패킹된 포맷]은 주소 정렬을 위한 것입니다. 예를 들어, `VK_FORMAT_A8B8G8R8_UNORM_PACK32` 와 `VK_FORMAT_R8G8B8A8_UNORM` 은 매우 비슷해 보이지만 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fxvertex-input-extraction[사양서의 정점 입력 추출 섹션]의 공식을 사용하면 달라집니다.
 
 ____
 attribAddress = bufferBindingAddress + vertexOffset + attribDesc.offset;
@@ -125,4 +125,4 @@ ____
 
 === 외부(External)
 
-현재 `VK_ANDROID_external_memory_android_hardware_buffer` 확장 기능으로만 지원되고 있습니다. 이 확장 기능을 사용하면 안드로이드 애플리케이션이 구현에서 정의된 외부 포맷을 가져와서 xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc[VkSamplerYcbcrConversion]과 함께 사용할 수 있습니다. 이러한 외부 포맷에는 허용되는 많은 제한 사항이 있으며, 이는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#memory-external-android-hardware-buffer-external-formats[사양서에 기재되어] 있습니다.
+현재 `VK_ANDROID_external_memory_android_hardware_buffer` 확장 기능으로만 지원되고 있습니다. 이 확장 기능을 사용하면 안드로이드 애플리케이션이 구현에서 정의된 외부 포맷을 가져와서 xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc[VkSamplerYcbcrConversion]과 함께 사용할 수 있습니다. 이러한 외부 포맷에는 허용되는 많은 제한 사항이 있으며, 이는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#memory-external-android-hardware-buffer-external-formats[사양서에 기재되어] 있습니다.

--- a/lang/kor/chapters/layers.adoc
+++ b/lang/kor/chapters/layers.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[layers]]
 = 레이어(Layers)
 
-레이어는 Vulkan 시스템을 보강하는 옵션 요소입니다. 레이어는 애플리케이션에서 하드웨어에 이르기까지 기존의 Vulkan 함수를 가로채고, 평가하고, 수정할 수 있습니다. 레이어 속성은 애플리케이션에서 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkEnumerateInstanceLayerProperties[vkEnumerateInstanceLayerProperties]를 사용하여 쿼리할 수 있습니다.
+레이어는 Vulkan 시스템을 보강하는 옵션 요소입니다. 레이어는 애플리케이션에서 하드웨어에 이르기까지 기존의 Vulkan 함수를 가로채고, 평가하고, 수정할 수 있습니다. 레이어 속성은 애플리케이션에서 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkEnumerateInstanceLayerProperties[vkEnumerateInstanceLayerProperties]를 사용하여 쿼리할 수 있습니다.
 
 == 레이어 사용
 
@@ -22,7 +22,7 @@ Vulkan Configurator 사용에 대한 자세한 내용은 link:https://vulkan.lun
 
 == 장치 레이어 사용 중단(Device Layers Deprecation)
 
-예전에는 인스턴스 레이어와 장치 레이어가 모두 있었지만, 디바이스 레이어는 Vulkan 초기에 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation[사용 중단]되어있으므로 피해야 합니다.
+예전에는 인스턴스 레이어와 장치 레이어가 모두 있었지만, 디바이스 레이어는 Vulkan 초기에 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation[사용 중단]되어있으므로 피해야 합니다.
 
 == 레이어 작성
 

--- a/lang/kor/chapters/mapping_data_to_shaders.adoc
+++ b/lang/kor/chapters/mapping_data_to_shaders.adoc
@@ -13,7 +13,7 @@ ifndef::images[:images: images/]
 모든 SPIR-V 어셈블리는 glslangValidator로 생성되었습니다.
 ====
 
-이 장에서는 데이터를 매핑하기 위한 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces[Vulkan과 SPIR-V의 인터페이스] 방법에 대해 설명합니다. `vkAllocateMemory` 에서 할당된 `VkDeviceMemory` 객체를 사용하여 Vulkan으로부터의 데이터를 SPIR-V 쉐이더가 올바르게 이용할 수 있도록 적절히 매핑하는 것은 애플리케이션의 책임입니다.
+이 장에서는 데이터를 매핑하기 위한 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces[Vulkan과 SPIR-V의 인터페이스] 방법에 대해 설명합니다. `vkAllocateMemory` 에서 할당된 `VkDeviceMemory` 객체를 사용하여 Vulkan으로부터의 데이터를 SPIR-V 쉐이더가 올바르게 이용할 수 있도록 적절히 매핑하는 것은 애플리케이션의 책임입니다.
 
 Vulkan 코어에서는 Vulkan 애플리케이션의 데이터를 매핑하여 SPIR-V와 인터페이스하는 5가지 기본 방법이 있습니다:
 
@@ -102,11 +102,11 @@ vkEndCommandBuffer();
 [[descriptors]]
 == 디스크립터(Descriptors)
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets[리소스 디스크립터]는 유니폼 버퍼, 스토리지 버퍼, 샘플러 등의 데이터를 Vulkan의 임의의 쉐이더 스테이지에 매핑하는 핵심 방법입니다. 개념적으로 디스크립터는 쉐이더가 사용할 수 있는 메모리에 대한 포인터로 생각하면 됩니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets[리소스 디스크립터]는 유니폼 버퍼, 스토리지 버퍼, 샘플러 등의 데이터를 Vulkan의 임의의 쉐이더 스테이지에 매핑하는 핵심 방법입니다. 개념적으로 디스크립터는 쉐이더가 사용할 수 있는 메모리에 대한 포인터로 생각하면 됩니다.
 
-Vulkan에는 다양한 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkDescriptorType[디스크립터 유형]이 있으며, 각 유형이 무엇을 허용하고 있는지 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-types[상세하게 설명되어 있습니다].
+Vulkan에는 다양한 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDescriptorType[디스크립터 유형]이 있으며, 각 유형이 무엇을 허용하고 있는지 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-types[상세하게 설명되어 있습니다].
 
-디스크립터는 쉐이더에 바인딩되는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-sets[디스크립터 세트]로 함께 그룹화됩니다. 디스크립터 세트 안에 디스크립터가 하나만 있더라도 쉐이더에 바인딩할 때는 `VkDescriptorSet` 전체가 사용됩니다.
+디스크립터는 쉐이더에 바인딩되는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-sets[디스크립터 세트]로 함께 그룹화됩니다. 디스크립터 세트 안에 디스크립터가 하나만 있더라도 쉐이더에 바인딩할 때는 `VkDescriptorSet` 전체가 사용됩니다.
 
 === 예제
 
@@ -182,9 +182,9 @@ image::../../../chapters/images/mapping_data_to_shaders_descriptor_2.png[mapping
 [[descriptor-types]]
 === 디스크립터 유형
 
-Vulkan 사양서에는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-storage-class-correspondence[쉐이더 리소스와 스토리지 클래스 대응표]가 있으며 각 디스크립터 유형이 SPIR-V에서 어떻게 매핑되어야 하는지 설명되어있습니다.
+Vulkan 사양서에는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-storage-class-correspondence[쉐이더 리소스와 스토리지 클래스 대응표]가 있으며 각 디스크립터 유형이 SPIR-V에서 어떻게 매핑되어야 하는지 설명되어있습니다.
 
-다음은 각 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-types[디스크립터 유형]에 대한 GLSL 및 SPIR-V 매핑의 예시입니다.
+다음은 각 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#descriptorsets-types[디스크립터 유형]에 대한 GLSL 및 SPIR-V 매핑의 예시입니다.
 
 GLSL의 경우 자세한 내용은 link:https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf[GLSL 사양 - 12.2.4. Vulkan 전용: 샘플러, 이미지, 텍스쳐 및 버퍼]에서 확인할 수 있습니다.
 
@@ -461,7 +461,7 @@ OpDecorate %inputAttachment InputAttachmentIndex 0
 [[specialization-constants]]
 == 특수화 상수(Specialization Constants)
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-specialization-constants[특수화 상수]는 `VkPipeline` 생성 시 SPIR-V의 상수 값을 지정할 수 있는 메커니즘입니다. 이는 고수준 쉐이딩 언어(GLSL, HLSL 등)에서 전처리기 매크로 사용을 대체할 수 있는 강력한 기능입니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#pipelines-specialization-constants[특수화 상수]는 `VkPipeline` 생성 시 SPIR-V의 상수 값을 지정할 수 있는 메커니즘입니다. 이는 고수준 쉐이딩 언어(GLSL, HLSL 등)에서 전처리기 매크로 사용을 대체할 수 있는 강력한 기능입니다.
 
 === 예제
 
@@ -563,13 +563,13 @@ vkCreateGraphicsPipelines(&pipelineInfo);
 [[physical-storage-buffer]]
 == 물리적 스토리지 버퍼(Physical Storage Buffer)
 
-Vulkan 1.2에서 승격된 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address] 확장을 통해 "`쉐이더 내에 포인터`" 를 가진 기능이 추가되었습니다. 애플리케이션은 SPIR-V의 `PhysicalStorageBuffer` 스토리지 클래스를 사용하여 `vkGetBufferDeviceAddress` 를 호출하면 `VkDeviceAddress` 를 메모리로 반환할 수 있습니다.
+Vulkan 1.2에서 승격된 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address] 확장을 통해 "`쉐이더 내에 포인터`" 를 가진 기능이 추가되었습니다. 애플리케이션은 SPIR-V의 `PhysicalStorageBuffer` 스토리지 클래스를 사용하여 `vkGetBufferDeviceAddress` 를 호출하면 `VkDeviceAddress` 를 메모리로 반환할 수 있습니다.
 
 이것은 데이터를 쉐이더에 매핑하는 방법이긴 하지만, 쉐이더와 인터페이스 되는 것은 아닙니다. 예를 들어, 애플리케이션이 유니폼 버퍼에서 이를 사용하고 싶다면 `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` 와 `VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT` 를 모두 포함하는 `VkBuffer` 를 생성해야 합니다. 이 예제에서 Vulkan은 디스크립터를 사용하여 쉐이더와 인터페이스하지만, 그 이후에는 물리적 스토리지 버퍼를 사용하여 값을 업데이트할 수 있습니다.
 
 == 제한 사항
 
-Vulkan에는 한 번에 바인딩할 수 있는 데이터의 양에 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#limits[제한]이 있다는 점을 알아두는 것이 중요합니다.
+Vulkan에는 한 번에 바인딩할 수 있는 데이터의 양에 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits[제한]이 있다는 점을 알아두는 것이 중요합니다.
 
   * 입력 속성
   ** `maxVertexInputAttributes`

--- a/lang/kor/chapters/memory_allocation.adoc
+++ b/lang/kor/chapters/memory_allocation.adoc
@@ -15,13 +15,13 @@ Vulkan 메모리 관리에 관한 2개의 크로노스 프레젠테이션, link:
 
 == 서브 할당(Sub-allocation)
 
-서브 할당은 Vulkan에서 작업할 때 가장 좋은 접근 방식입니다. 또한 애플리케이션이 한 번에 사용할 수 있는 동시 활성 할당 수에 제한을 두는 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#limits-maxMemoryAllocationCount[maxMemoryAllocationCount]가 있다는 점도 중요합니다. OS나 드라이버 수준에서의 메모리 할당과 해제는 매우 느릴 수 있으며, 이것이 서브 할당의 또 다른 이유입니다. Vulkan 앱은 큰 할당을 생성한 다음 자체적으로 관리하는 것을 목표로 해야 합니다.
+서브 할당은 Vulkan에서 작업할 때 가장 좋은 접근 방식입니다. 또한 애플리케이션이 한 번에 사용할 수 있는 동시 활성 할당 수에 제한을 두는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-maxMemoryAllocationCount[maxMemoryAllocationCount]가 있다는 점도 중요합니다. OS나 드라이버 수준에서의 메모리 할당과 해제는 매우 느릴 수 있으며, 이것이 서브 할당의 또 다른 이유입니다. Vulkan 앱은 큰 할당을 생성한 다음 자체적으로 관리하는 것을 목표로 해야 합니다.
 
 image::../../../chapters/images/memory_allocation_sub_allocation.png[memory_allocation_sub_allocation.png]
 
 == 전송
 
-link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#VkPhysicalDeviceType[VkPhysicalDeviceType]은 외장형과 통합형(UMA(통합 메모리 아키텍처, Unified Memory Architecture)라고도 함)의 두 가지 주요 GPU 유형을 나타냅니다. 이 둘의 차이점을 이해하는 것이 성능에 중요합니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPhysicalDeviceType[VkPhysicalDeviceType]은 외장형과 통합형(UMA(통합 메모리 아키텍처, Unified Memory Architecture)라고도 함)의 두 가지 주요 GPU 유형을 나타냅니다. 이 둘의 차이점을 이해하는 것이 성능에 중요합니다.
 
 외장 그래픽 카드에는 장치에 자체 전용 메모리가 포함되어 있습니다. 데이터는 버스(예: PCIe)를 통해 전송되는데, 데이터 전송의 물리적 속도 제한으로 인해 일반적으로 병목 현상이 발생합니다. 일부 물리적 장치는 데이터 전송을 위한 전용 큐를 허용하는 `VK_QUEUE_TRANSFER_BIT` 로 큐를 알립니다. 일반적인 방법은 커맨드 버퍼를 통해 전송하기 전에 호스트 데이터를 복사할 _스테이징 버퍼_ 를 생성하여 장치 로컬 메모리로 복사하는 것입니다.
 

--- a/lang/kor/chapters/pipeline_cache.adoc
+++ b/lang/kor/chapters/pipeline_cache.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[pipeline-cache]]
 = 파이프라인 캐시(Pipeline Cache)
 
-파이프라인 캐싱은 이미 생성된 파이프라인을 재사용하기 위해 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#VkPipelineCache[VkPipelineCache] 객체와 함께 사용되는 기술입니다. 예를 들어 파이프라인을 생성할 때 쉐이더를 컴파일해야 하므로 파이프라인 생성에는 다소 비용이 많이 들 수 있습니다. 파이프라인 캐시의 가장 큰 장점은 파이프라인 상태를 파일에 저장하여 애플리케이션을 실행할 때마다 사용할 수 있으므로 생성 시 비용이 많이 드는 부분을 제거할 수 있다는 것입니다. 이 내용에 관해 link:https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/3D-BOF-SIGGRAPH_Jul16.pdf[SIGGRAPH 2016] (link:https://www.youtube.com/watch?v=owuJRPKIUAg&t=1045s[video]) 140번 슬라이드부터 파이프라인 캐싱에 대한 훌륭한 크로노스 그룹 프레젠테이션이 있습니다.
+파이프라인 캐싱은 이미 생성된 파이프라인을 재사용하기 위해 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPipelineCache[VkPipelineCache] 객체와 함께 사용되는 기술입니다. 예를 들어 파이프라인을 생성할 때 쉐이더를 컴파일해야 하므로 파이프라인 생성에는 다소 비용이 많이 들 수 있습니다. 파이프라인 캐시의 가장 큰 장점은 파이프라인 상태를 파일에 저장하여 애플리케이션을 실행할 때마다 사용할 수 있으므로 생성 시 비용이 많이 드는 부분을 제거할 수 있다는 것입니다. 이 내용에 관해 link:https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/3D-BOF-SIGGRAPH_Jul16.pdf[SIGGRAPH 2016] (link:https://www.youtube.com/watch?v=owuJRPKIUAg&t=1045s[video]) 140번 슬라이드부터 파이프라인 캐싱에 대한 훌륭한 크로노스 그룹 프레젠테이션이 있습니다.
 
 image::../../../chapters/images/pipeline_cache_cache.png[pipeline_cache_cache.png]
 

--- a/lang/kor/chapters/platforms.adoc
+++ b/lang/kor/chapters/platforms.adoc
@@ -54,4 +54,4 @@ Vulkan은 윈도우 7, 8, 10, 11에서 지원됩니다.
 
 == Others
 
-일부 임베디드 시스템은 Vulkan을 지원하는 것도 있어 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#display[디스플레이에 직접] 표시할 수 있습니다.
+일부 임베디드 시스템은 Vulkan을 지원하는 것도 있어 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#display[디스플레이에 직접] 표시할 수 있습니다.

--- a/lang/kor/chapters/pnext_and_stype.adoc
+++ b/lang/kor/chapters/pnext_and_stype.adoc
@@ -11,7 +11,7 @@ Vulkan을 처음 접하는 사람들은 Vulkan 사양서 곳곳에서 `pNext` �
 
 == 기본 구조체 2가지
 
-Vulkan API는 `VkBaseInStructure` 와 `VkBaseOutStructure` 라는 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#fundamentals-validusage-pNext[두 가지 기본 구조체를 제공]하여, 구조체 포인터 체인을 반복하는 편리한 방법으로 사용됩니다.
+Vulkan API는 `VkBaseInStructure` 와 `VkBaseOutStructure` 라는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-validusage-pNext[두 가지 기본 구조체를 제공]하여, 구조체 포인터 체인을 반복하는 편리한 방법으로 사용됩니다.
 
 `VkBaseInStructure` 의 `In` 은 `pNext` 가 `const *` 이며 이를 수신하는 로더, 레이어 및 드라이버에 대해 읽기 전용이라는 사실을 나타냅니다. `VkBaseOutStructure`의 `Out` 은 데이터를 애플리케이션에 다시 반환하는 데 사용되는 `pNext` 를 나타냅니다.
 

--- a/lang/kor/chapters/portability_initiative.adoc
+++ b/lang/kor/chapters/portability_initiative.adoc
@@ -10,7 +10,7 @@ ifndef::images[:images: images/]
 [NOTE]
 .공지
 ====
-현재 임시적으로 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_portability_subset.html[VK_KHR_portability_subset] 확장 기능은 link:https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_beta.h[vulkan_beta.h] 헤더를 통해 사용할 수 있습니다. 자세한 내용은 link:https://www.khronos.org/blog/fighting-fragmentation-vulkan-portability-extension-released-implementations-shipping[보도 자료]에서 확인할 수 있습니다.
+현재 임시적으로 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_portability_subset.html[VK_KHR_portability_subset] 확장 기능은 link:https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_beta.h[vulkan_beta.h] 헤더를 통해 사용할 수 있습니다. 자세한 내용은 link:https://www.khronos.org/blog/fighting-fragmentation-vulkan-portability-extension-released-implementations-shipping[보도 자료]에서 확인할 수 있습니다.
 
 // 번역 주* 이니셔티브(Initiaitve)에 대한 의미는 다음 link:https://https://www.lecturernews.com/news/articleView.html?idxno=114135[기사]에서 확인할 수 있으며, 여기서는 프로젝트로 번역하였습니다.
 ====

--- a/lang/kor/chapters/protected.adoc
+++ b/lang/kor/chapters/protected.adoc
@@ -12,7 +12,7 @@ ifndef::images[:images: images/]
 
 대부분의 OS는 명시적으로 공유하지 않는 한 애플리케이션이 다른 애플리케이션의 GPU 메모리에 접근하는 것을 허용하지 않습니다(예: xref:{chapters}extensions/external.adoc#external-memory[외부 메모리]). 보호 메모리의 일반적인 예는 DRM 콘텐츠를 저장하는 것으로, 프로세스에서 수정할 수 있지만(예: 이미지 필터링 또는 재생 컨트롤과 자막 합성) 비보호 메모리로 추출할 수 없어야 합니다. 데이터는 암호화된 상태로 전송되고 디스플레이의 픽셀에 도달할 때까지 암호화된 상태로 유지됩니다.
 
-Vulkan 사양서는 "`보호 장치 메모리`"가 무엇을 강제하는지 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#memory-protected-memory[자세히 설명하고 있습니다]. 다음은 보호 메모리를 사용하여 암호화된 전송을 올바르게 활성화하기 위해 필요한 사항에 대한 분석입니다.
+Vulkan 사양서는 "`보호 장치 메모리`"가 무엇을 강제하는지 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#memory-protected-memory[자세히 설명하고 있습니다]. 다음은 보호 메모리를 사용하여 암호화된 전송을 올바르게 활성화하기 위해 필요한 사항에 대한 분석입니다.
 
 == 지원 여부 확인
 
@@ -88,7 +88,7 @@ vkGetDeviceQueue2(deviceHandle, &info, &protectedQueue);
 
 보호된 스왑체인을 사용하는 `vkGetSwapchainImagesKHR` 의 모든 `VkImage` 는 `VK_IMAGE_CREATE_PROTECTED_BIT` 으로 이미지를 생성한 것과 동일합니다.
 
-가끔씩 `VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` 플래그가 설정된 상태에서 스왑체인을 생성할 수 있는지 여부를 알 수 없는 경우가 있습니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_surface_protected_capabilities.html[VK_KHR_surface_protected_capabilities] 확장 기능은 이것을 알 수 없는 플랫폼에 공개되어 있습니다.
+가끔씩 `VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` 플래그가 설정된 상태에서 스왑체인을 생성할 수 있는지 여부를 알 수 없는 경우가 있습니다. link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_surface_protected_capabilities.html[VK_KHR_surface_protected_capabilities] 확장 기능은 이것을 알 수 없는 플랫폼에 공개되어 있습니다.
 
 == 보호 커맨트 버퍼(Protected command buffer)
 

--- a/lang/kor/chapters/push_constants.adoc
+++ b/lang/kor/chapters/push_constants.adoc
@@ -33,7 +33,7 @@ API를 통해 작성할 수 있고 쉐이더에서 액세스할 수 있는 작�
 [[pc-shader-code]]
 === 쉐이더 코드
 
-쉐이더 관점에서 푸시 상수는 유니폼 버퍼와 유사합니다. Vulkan과 SPIR-V 사이의 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-pushconst[푸시 상수 인터페이스]는 사양서에 자세하게 설명되어 있습니다.
+쉐이더 관점에서 푸시 상수는 유니폼 버퍼와 유사합니다. Vulkan과 SPIR-V 사이의 link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-pushconst[푸시 상수 인터페이스]는 사양서에 자세하게 설명되어 있습니다.
 
 간단한 GLSL 프래그먼트 쉐이더 예제 (link:https://godbolt.org/z/93WaYd8dE[온라인 체험]):
 
@@ -68,12 +68,12 @@ void main() {
 %access_chain   = OpAccessChain %pc_v4float_ptr %pc_var %int_0
 ----
 
-이것은 `Block` 수식을 가진 `OpTypeStruct` 타입이라는 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-pushconst[Vulkan spec]의 기술과 일치합니다.
+이것은 `Block` 수식을 가진 `OpTypeStruct` 타입이라는 link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#interfaces-resources-pushconst[Vulkan spec]의 기술과 일치합니다.
 
 [[pc-pipeline-layout]]
 === 파이프라인 레이아웃
 
-`vkCreatePipelineLayout` 을 호출할 때, the link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPushConstantRange.html[푸시 상수 범위]는 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineLayoutCreateInfo.html[VkPipelineLayoutCreateInfo]에서 설정해야 합니다.
+`vkCreatePipelineLayout` 을 호출할 때, the link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPushConstantRange.html[푸시 상수 범위]는 link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/VkPipelineLayoutCreateInfo.html[VkPipelineLayoutCreateInfo]에서 설정해야 합니다.
 
 위의 쉐이더를 사용한 예제:
 
@@ -99,7 +99,7 @@ vkCreatePipelineLayout(device, &create_info, NULL, &pipeline_layout);
 [[pc-updating]]
 === Updating at record time
 
-마지막으로, 푸시 상수 값은 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdPushConstants.html[vkCmdPushConstants]를 사용하여 원하는 값으로 업데이트해야 합니다.
+마지막으로, 푸시 상수 값은 link:https://www.khronos.org/registry/vulkan/specs/latest/man/html/vkCmdPushConstants.html[vkCmdPushConstants]를 사용하여 원하는 값으로 업데이트해야 합니다.
 
 [source,cpp]
 ----
@@ -158,14 +158,14 @@ image::../../../chapters/images/push_constant_offset.png[push_constant_offset]
 [[pc-pipeline-layout-compatibility]]
 == 파이프라인 레이아웃 호환성
 
-Vulkan 사양서에는 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-compatibility[푸시 상수에 대한 호환성]을 다음과 같이 정의합니다
+Vulkan 사양서에는 link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-compatibility[푸시 상수에 대한 호환성]을 다음과 같이 정의합니다
 
 [NOTE]
 ====
 파이프라인 레이아웃이 동일한 푸시 상수 범위로 생성된 경우
 ====
 
-즉, link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#pipeline-bindpoint-commands[바인딩된 파이프라인 커맨드] (`vkCmdDraw`, `vkCmdDispatch` 등)가 실행되기 직전의 `vkCmdPushConstants` 와 `vkCmdBindPipeline` (적절한 `VkPipelineBindPoint` 용으로)에서 사용된 `VkPipelineLayout` 은 **동일한** `VkPushConstantRange` 를 가지고 있어야 한다는 것을 뜻합니다.
+즉, link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#pipeline-bindpoint-commands[바인딩된 파이프라인 커맨드] (`vkCmdDraw`, `vkCmdDispatch` 등)가 실행되기 직전의 `vkCmdPushConstants` 와 `vkCmdBindPipeline` (적절한 `VkPipelineBindPoint` 용으로)에서 사용된 `VkPipelineLayout` 은 **동일한** `VkPushConstantRange` 를 가지고 있어야 한다는 것을 뜻합니다.
 
 [[pc-lifetime]]
 == 푸시 상수의 수명
@@ -180,7 +180,7 @@ Vulkan 사양서에는 link:https://www.khronos.org/registry/vulkan/specs/1.3-ex
 [[pc-binding-descriptor-sets]]
 === 디스크립터 세트가 바인딩에 미치는 영향은 없습니다
 
-푸시 상수는 디스크립터에 연결되지 않으므로 `vkCmdBindDescriptorSets` 를 사용해도 푸시 상수의 수명이나 link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#descriptorsets-compatibility[파이프라인 레이아웃 호환성]에 영향을 미치지 않습니다.
+푸시 상수는 디스크립터에 연결되지 않으므로 `vkCmdBindDescriptorSets` 를 사용해도 푸시 상수의 수명이나 link:https://www.khronos.org/registry/vulkan/specs/latest/html/vkspec.html#descriptorsets-compatibility[파이프라인 레이아웃 호환성]에 영향을 미치지 않습니다.
 
 [[pc-mixing-bind-points]]
 === 바인딩 포인트 혼합

--- a/lang/kor/chapters/querying_extensions_features.adoc
+++ b/lang/kor/chapters/querying_extensions_features.adoc
@@ -40,17 +40,17 @@ Vulkan에 현재 존재하지 않는 새로운 기능이 필요할 때가 많습
 자세한 내용은 xref:{chapters}enabling_features.adoc#enabling-features[기능 활성화] 챕터를 참조하세요.
 ====
 
-기능(Features)은 모든 구현에서 지원되지 않은 기능(functionality)을 설명합니다. 기능은 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkGetPhysicalDeviceFeatures[쿼리한] 후 `VkDevice` 를 생성할 때 활성화할 수 있습니다. the link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#features[전체 기능 목록] 외에도, 최신 Vulkan 버전 또는 확장 기능 사용으로 인해 일부 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-requirements[필수 기능]이 있습니다.
+기능(Features)은 모든 구현에서 지원되지 않은 기능(functionality)을 설명합니다. 기능은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceFeatures[쿼리한] 후 `VkDevice` 를 생성할 때 활성화할 수 있습니다. the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features[전체 기능 목록] 외에도, 최신 Vulkan 버전 또는 확장 기능 사용으로 인해 일부 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-requirements[필수 기능]이 있습니다.
 
 일반적인 기법으로는 확장 기능이 `pNext` 로 전달될 수 있는 새로운 구조체를 공개함으로써 쿼리 가능한 기능을 더 추가하는 것입니다.
 
 == 제한(Limits)
 
-제한은 구현에 따라 달리지는 최솟값, 최댓값 및 애플리케이션이 알아야 할 기타 기기 특성입니다. link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#limits[모든 제한 목록] 외에도, 일부 제한에는 Vulkan 구현에서 보장하는 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#limits-minmax[최소/최대 필수값]이 있습니다.
+제한은 구현에 따라 달리지는 최솟값, 최댓값 및 애플리케이션이 알아야 할 기타 기기 특성입니다. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits[모든 제한 목록] 외에도, 일부 제한에는 Vulkan 구현에서 보장하는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-minmax[최소/최대 필수값]이 있습니다.
 
 == 포맷(Formats)
 
-Vulkan은 많은 `VkFormat` 을 제공하고 있습니다. `VkFormat`은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] 비트마스크를 보유하는 복수의 `VkFormatFeatureFlags` 를 가지고 쿼리할 수 있습니다.
+Vulkan은 많은 `VkFormat` 을 제공하고 있습니다. `VkFormat`은 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkFormatFeatureFlagBits.html[VkFormatFeatureFlagBits] 비트마스크를 보유하는 복수의 `VkFormatFeatureFlags` 를 가지고 쿼리할 수 있습니다.
 
 자세한 내용은 xref:{chapters}formats.adoc#feature-support[포맷 챕터]를 참조하세요.
 

--- a/lang/kor/chapters/queues.adoc
+++ b/lang/kor/chapters/queues.adoc
@@ -32,12 +32,12 @@ link:https://gpuopen.com/learn/concurrent-execution-asynchronous-queues/[AMD] �
 
 `VkQueue` 가 지원할 수 있는 연산에는 다양한 유형이 있습니다. "`큐 패밀리`" 는 `VkQueueFamilyProperties` 에 명시된 대로 공통 속성을 가지며 동일한 기능을 지원하는 `VkQueue`&#8203; 의 집합을 설명할 뿐입니다.
 
-다음은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkQueueFlagBits.html[VkQueueFlagBits]에 있는 큐 연산입니다:
+다음은 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkQueueFlagBits.html[VkQueueFlagBits]에 있는 큐 연산입니다:
 
   * `VK_QUEUE_GRAPHICS_BIT` 는 `vkCmdDraw*` 및 그래픽스 파이프라인 명령에 사용됩니다
   * `VK_QUEUE_COMPUTE_BIT` 는 `vkCmdDispatch*` , `vkCmdTraceRays*` 및 컴퓨트 파이프라인 관련 명령에 사용됩니다.
   * `VK_QUEUE_TRANSFER_BIT` 는 모든 전송 명령에 사용됩니다.
-  ** 사양서의 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineStageFlagBits.html[VK_PIPELINE_STAGE_TRANSFER_BIT]는 "`전송 명령`" 을 설명합니다.
+  ** 사양서의 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkPipelineStageFlagBits.html[VK_PIPELINE_STAGE_TRANSFER_BIT]는 "`전송 명령`" 을 설명합니다.
   ** `VK_QUEUE_TRANSFER_BIT` 만 있는 큐 패밀리는 일반적으로 link:https://en.wikipedia.org/wiki/Direct_memory_access[DMA]를 사용하여 호스트와 개별 GPU의 장치 메모리 간에 데이터를 비동기적으로 전송하기 위한 것으로, 독립적인 그래픽/컴퓨팅 처리와 동시에 전송을 수행할 수 있습니다.
   ** `VK_QUEUE_GRAPHICS_BIT` 및 `VK_QUEUE_COMPUTE_BIT` 는 항상 암시적으로 `VK_QUEUE_TRANSFER_BIT` 명령을 받을 수 있습니다.
   * `VK_QUEUE_SPARSE_BINDING_BIT` 는 xref:{chapters}sparse_resources.adoc#sparse-resources[희소 리소스]를 `vkQueueBindSparse` 로 메모리에 바인딩하는 데 사용됩니다.

--- a/lang/kor/chapters/robustness.adoc
+++ b/lang/kor/chapters/robustness.adoc
@@ -25,37 +25,37 @@ image::../../../chapters/images/robustness_flow.png[robustness_flow.png]
 
 == Vulkan이 코어로 제공하는 것
 
-모든 Vulkan 구현은 `robustBufferAccess` 기능을 지원해야 합니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess[사양서는 어떤 것이 범위를 벗어난 것으로 간주되는지] 그리고 어떻게 처리해야 하는지를 설명합니다.구현에는 `robustBufferAccess` 에 대해 어느 정도의 유연성이 부여됩니다. 예를 들어 `w` 값이 범위를 벗어난 `vec4(x,y,z,w)` 에 접근하는 경우, `x`, `y`, `z` 도 범위를 벗어난 것으로 간주할지 여부를 구현에서 결정할 수 있도록 사양에서 허용하고 있기 때문입니다.
+모든 Vulkan 구현은 `robustBufferAccess` 기능을 지원해야 합니다. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess[사양서는 어떤 것이 범위를 벗어난 것으로 간주되는지] 그리고 어떻게 처리해야 하는지를 설명합니다.구현에는 `robustBufferAccess` 에 대해 어느 정도의 유연성이 부여됩니다. 예를 들어 `w` 값이 범위를 벗어난 `vec4(x,y,z,w)` 에 접근하는 경우, `x`, `y`, `z` 도 범위를 벗어난 것으로 간주할지 여부를 구현에서 결정할 수 있도록 사양에서 허용하고 있기 때문입니다.
 
-(Vulkan 1.2의 핵심인) `VK_EXT_descriptor_indexing` 에 있는 바인딩 후 업데이트 기능을 다루는 경우, 구현이 `robustBufferAccess` 와 바인딩 후 디스크립터를 업데이트하는 기능을 모두 지원할 수 있는지를 나타내는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#limits-robustBufferAccessUpdateAfterBind[robustBufferAccessUpdateAfterBind]를 알아두는 것이 중요합니다.
+(Vulkan 1.2의 핵심인) `VK_EXT_descriptor_indexing` 에 있는 바인딩 후 업데이트 기능을 다루는 경우, 구현이 `robustBufferAccess` 와 바인딩 후 디스크립터를 업데이트하는 기능을 모두 지원할 수 있는지를 나타내는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-robustBufferAccessUpdateAfterBind[robustBufferAccessUpdateAfterBind]를 알아두는 것이 중요합니다.
 
-`robustBufferAccess` 기능은 이미지가 아닌 버퍼만 다루기 때문에 몇 가지 제한이 있습니다. 또한 접근 중인 버퍼의 데이터를 수정하기 위해 범위를 벗어난 쓰기나 아토믹을 허용해버립니다. 더 강력한 형태의 견고성을 원하는 애플리케이션의 경우, link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2]가 있습니다.
+`robustBufferAccess` 기능은 이미지가 아닌 버퍼만 다루기 때문에 몇 가지 제한이 있습니다. 또한 접근 중인 버퍼의 데이터를 수정하기 위해 범위를 벗어난 쓰기나 아토믹을 허용해버립니다. 더 강력한 형태의 견고성을 원하는 애플리케이션의 경우, link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2]가 있습니다.
 
-이미지가 범위를 벗어난 경우, 코어 Vulkan에서는 스토어나 아토믹이 접근하려는 메모리에 영향을 주지 않는 것이 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-output-coordinate-validation[보장되어 있습니다].
+이미지가 범위를 벗어난 경우, 코어 Vulkan에서는 스토어나 아토믹이 접근하려는 메모리에 영향을 주지 않는 것이 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#textures-output-coordinate-validation[보장되어 있습니다].
 
 == VK_EXT_image_robustness
 
 === robustImageAccess
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_EXT_image_robustness[VK_EXT_image_robustness] 의 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustImageAccess[robustImageAccess] 기능은 이미지 뷰 크기에 대한 범위를 넘는 접근을 검사할 수 있습니다. 이미지 범위에 접근이 있는 경우 `(0, 0, 0, 0)` 또는 `(0, 0, 0, 1)` 를 반환합니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_EXT_image_robustness[VK_EXT_image_robustness] 의 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustImageAccess[robustImageAccess] 기능은 이미지 뷰 크기에 대한 범위를 넘는 접근을 검사할 수 있습니다. 이미지 범위에 접근이 있는 경우 `(0, 0, 0, 0)` 또는 `(0, 0, 0, 1)` 를 반환합니다.
 
 `robustImageAccess` 기능은 유효하지 않은 LOD에 접근할 때 반환되는 값에 대한 보장을 제공하지 않으며, 아직 정의되지 않은 동작입니다.
 
 == VK_EXT_robustness2
 
-D3D12와 같은 다른 API에서 포팅된 애플리케이션과 같은 일부 애플리케이션은 `robustBufferAccess` 와 `robustImageAccess` 가 제공하는 것보다 더 엄격한 보장을 필요로 합니다. 다음 섹션에서 설명하는 3 가지 새로운 견고성 기능을 공개하여 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] 확장 기능을 추가합니다. 일부 구현의 경우 이러한 추가 보장은 성능 저하를 초래할 수 있습니다. 추가 견고성이 필요하지 않은 애플리케이션은 가능하면 `robustBufferAccess` 및/또는 `robustImageAccess` 를 대신 사용하는 것이 좋습니다.
+D3D12와 같은 다른 API에서 포팅된 애플리케이션과 같은 일부 애플리케이션은 `robustBufferAccess` 와 `robustImageAccess` 가 제공하는 것보다 더 엄격한 보장을 필요로 합니다. 다음 섹션에서 설명하는 3 가지 새로운 견고성 기능을 공개하여 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_robustness2.html[VK_EXT_robustness2] 확장 기능을 추가합니다. 일부 구현의 경우 이러한 추가 보장은 성능 저하를 초래할 수 있습니다. 추가 견고성이 필요하지 않은 애플리케이션은 가능하면 `robustBufferAccess` 및/또는 `robustImageAccess` 를 대신 사용하는 것이 좋습니다.
 
 === robustBufferAccess2
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess2[robustBufferAccess2] 기능은 `robustBufferAccess` 의 상위 집합으로 볼 수 있습니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess2[robustBufferAccess2] 기능은 `robustBufferAccess` 의 상위 집합으로 볼 수 있습니다.
 
-이 기능을 활성화하면, 모든 범위를 벗어난 쓰기나 아토믹이 메모리 백업 버퍼를 수정할 수 없게 됩니다. 또한 `robustBufferAccess2` 기능은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustBufferAccess[사양서에 설명된 대로] 범위를 벗어난 접근을 할 때 다양한 유형의 버퍼에 대해 반환해야 하는 값을 강제 적용합니다.
+이 기능을 활성화하면, 모든 범위를 벗어난 쓰기나 아토믹이 메모리 백업 버퍼를 수정할 수 없게 됩니다. 또한 `robustBufferAccess2` 기능은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustBufferAccess[사양서에 설명된 대로] 범위를 벗어난 접근을 할 때 다양한 유형의 버퍼에 대해 반환해야 하는 값을 강제 적용합니다.
 
-버퍼가 바인딩되는 위치의 정렬은 구현마다 다르므로, link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceRobustness2PropertiesEXT.html[VkPhysicalDeviceRobustness2PropertiesEXT]에서 `robustUniformBufferAccessSizeAlignment` 및 `robustStorageBufferAccessSizeAlignment` 를 쿼리하는 것이 중요합니다.
+버퍼가 바인딩되는 위치의 정렬은 구현마다 다르므로, link:https://registry.khronos.org/vulkan/specs/latest/man/html/VkPhysicalDeviceRobustness2PropertiesEXT.html[VkPhysicalDeviceRobustness2PropertiesEXT]에서 `robustUniformBufferAccessSizeAlignment` 및 `robustStorageBufferAccessSizeAlignment` 를 쿼리하는 것이 중요합니다.
 
 === robustImageAccess2
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-robustImageAccess2[robustImageAccess2] 기능은 `robustImageAccess` 의 상위 집합으로 볼 수 있습니다. 이 기능은 접근하는 이미지 뷰의 차원에 대한 범위를 벗어난 검사를 기반으로 하며, 반환할 수 있는 값에 대해 더 엄격한 요구 사항을 추가합니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-robustImageAccess2[robustImageAccess2] 기능은 `robustImageAccess` 의 상위 집합으로 볼 수 있습니다. 이 기능은 접근하는 이미지 뷰의 차원에 대한 범위를 벗어난 검사를 기반으로 하며, 반환할 수 있는 값에 대해 더 엄격한 요구 사항을 추가합니다.
 
 `robustImageAccess2` 를 사용하여 R, RG, 또는 RGB 포맷에 대한 범위를 벗어난 접근은 `(0, 0, 0, 1)` 을 반환합니다. `VK_FORMAT_R8G8B8A8_UNORM` 과 같은 RGBA 포맷의 경우, `(0, 0, 0, 0)` 을 반환합니다.
 
@@ -63,13 +63,13 @@ link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#f
 
 === nullDescriptor
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-nullDescriptor[nullDescriptor] 기능이 활성화되지 않은 경우, `VkDescriptorSet` 을 업데이트할 때, 쉐이더에서 정적으로 사용되지 않은 디스크립터라도 이를 지원하는 모든 리소스는 null이 아니어야 합니다. 이 기능을 사용하면 null 리소스 또는 뷰가 디스크립터를 지원할 수 있습니다. null 디스크립터에서 로드하면 0 값이 반환되고 null 디스크립터에 대한 스토어 및 아토믹이 삭제됩니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-nullDescriptor[nullDescriptor] 기능이 활성화되지 않은 경우, `VkDescriptorSet` 을 업데이트할 때, 쉐이더에서 정적으로 사용되지 않은 디스크립터라도 이를 지원하는 모든 리소스는 null이 아니어야 합니다. 이 기능을 사용하면 null 리소스 또는 뷰가 디스크립터를 지원할 수 있습니다. null 디스크립터에서 로드하면 0 값이 반환되고 null 디스크립터에 대한 스토어 및 아토믹이 삭제됩니다.
 
 `nullDescriptor` 기능을 사용하면 `vkCmdBindVertexBuffers::pBuffers` 가 null인 정점 입력 바인딩에 접근을 가능하게 합니다.
 
 == VK_EXT_pipeline_robustness
 
-일부 구현에서는 견고성이 성능에 영향을 미칠 수 있으므로, 개발자가 필요한 경우에만 견고성을 요청할 수 있도록 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_robustness.html[VK_EXT_pipeline_robustness] 확장 기능을 추가했습니다.
+일부 구현에서는 견고성이 성능에 영향을 미칠 수 있으므로, 개발자가 필요한 경우에만 견고성을 요청할 수 있도록 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_pipeline_robustness.html[VK_EXT_pipeline_robustness] 확장 기능을 추가했습니다.
 
 `VkPipeline` 생성 시 파이프라인 전체 또는 파이프라인 스테이지별로 버퍼, 이미지 및 정점 입력 리소스에 접근하려는 견고성 동작을 지정하기 위해 하나 이상의 `VkPipelineRobustnessCreateInfoEXT` 구조체를 전달할 수 있습니다.
 

--- a/lang/kor/chapters/shader_memory_layout.adoc
+++ b/lang/kor/chapters/shader_memory_layout.adoc
@@ -8,14 +8,14 @@ ifndef::images[:images: images/]
 [[shader-memory-layout]]
 = 쉐이더 메모리 레이아웃
 
-구현이 인터페이스에서 메모리로 접근할 때, **메모리 레이아웃**이 어떻게 구성되는지 알아야 합니다. 여기에는 **오프셋**, **스트라이드(stride)**, **정렬(alignments)**와 같은 것들이 포함됩니다. Vulkan 사양서에는 이에 대한 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-layout[전용 섹션]이 있지만, 사양서 언어에 복잡성을 더하는 다양한 확장으로 인해 파싱하기가 어려울 수 있습니다. 이 장에서는 Vulkan이 사용하는 모든 메모리 레이아웃 개념을 몇 가지 고수준 쉐이더 언어(GLSL) 예제와 함께 설명합니다.
+구현이 인터페이스에서 메모리로 접근할 때, **메모리 레이아웃**이 어떻게 구성되는지 알아야 합니다. 여기에는 **오프셋**, **스트라이드(stride)**, **정렬(alignments)**와 같은 것들이 포함됩니다. Vulkan 사양서에는 이에 대한 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-layout[전용 섹션]이 있지만, 사양서 언어에 복잡성을 더하는 다양한 확장으로 인해 파싱하기가 어려울 수 있습니다. 이 장에서는 Vulkan이 사용하는 모든 메모리 레이아웃 개념을 몇 가지 고수준 쉐이더 언어(GLSL) 예제와 함께 설명합니다.
 
 // stride : 사전적 정의는 보폭으로 연속된 정점 간의 바이트 오프셋을 의미
 
 [[alignment-requirements]]
 == 정렬 요건(Alignment Requirements)
 
-Vulkan에는 인터페이스 객체를 배치할 수 있는 3가지 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-alignment-requirements[정렬 요건]이 있습니다.
+Vulkan에는 인터페이스 객체를 배치할 수 있는 3가지 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-alignment-requirements[정렬 요건]이 있습니다.
 
 - 확장 정렬 (`std140` 이라고도 함)
 - 기본 정렬 (`std430` 이라고도 함)
@@ -37,7 +37,7 @@ Vulkan에는 인터페이스 객체를 배치할 수 있는 3가지 link:https:/
 Vulkan 1.2에서 코어 승격
 ====
 
-이 확장을 통해 UBO에서 `std430` 메모리 레이아웃을 사용할 수 있습니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-resources-standard-layout[Vulkan 표준 버퍼 레이아웃 인터페이스]는 이 가이드 외부에서 확인할 수 있습니다. 이러한 메모리 레이아웃 변경은 푸시 상수 및 SSBO와 같은 다른 저장소 항목에서 이미 std430 스타일 레이아웃을 허용하므로 `Uniforms` 에만 적용됩니다.
+이 확장을 통해 UBO에서 `std430` 메모리 레이아웃을 사용할 수 있습니다. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-standard-layout[Vulkan 표준 버퍼 레이아웃 인터페이스]는 이 가이드 외부에서 확인할 수 있습니다. 이러한 메모리 레이아웃 변경은 푸시 상수 및 SSBO와 같은 다른 저장소 항목에서 이미 std430 스타일 레이아웃을 허용하므로 `Uniforms` 에만 적용됩니다.
 
 `uniformBufferStandardLayout` 기능이 필요한 경우의 일례로 애플리케이션이 UBO 배열의 스트라이드를 `확장 정렬` 로 제한하고 싶지 않을 때입니다.
 

--- a/lang/kor/chapters/sparse_resources.adoc
+++ b/lang/kor/chapters/sparse_resources.adoc
@@ -7,11 +7,11 @@ ifndef::images[:images: images/]
 [[sparse-resources]]
 = 희소 리소스(Sparse Resources)
 
-Vulkan은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory[희소 리소스]는 하나 이상의 `VkDeviceMemory` 할당에 비연속적으로 바인딩할 수 있는 `VkBuffer` 와 `VkImage` 객체를 생성하는 방법입니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-sparseresourcefeatures[사양서]에 희소 리소스의 여러 측면과 특징에 대해서 잘 설명되어 있습니다. link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_sparse_resource_implementation_guidelines[구현 가이드라인]에서 지적한 바와 같이 대부분의 구현은 희소 리소스를 사용하여 메모리의 선형 가상 주소 범위를 애플리케이션에 공개하는 한편 바인딩할 때 각 희소 블록을 물리 페이지에 매핑합니다.
+Vulkan은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory[희소 리소스]는 하나 이상의 `VkDeviceMemory` 할당에 비연속적으로 바인딩할 수 있는 `VkBuffer` 와 `VkImage` 객체를 생성하는 방법입니다. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory-sparseresourcefeatures[사양서]에 희소 리소스의 여러 측면과 특징에 대해서 잘 설명되어 있습니다. link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_sparse_resource_implementation_guidelines[구현 가이드라인]에서 지적한 바와 같이 대부분의 구현은 희소 리소스를 사용하여 메모리의 선형 가상 주소 범위를 애플리케이션에 공개하는 한편 바인딩할 때 각 희소 블록을 물리 페이지에 매핑합니다.
 
 == 희소 메모리 바인딩
 
-`vkBindBufferMemory()` 또는 `vkBindImageMemory()` 를 호출하는 일반 리소스와 달리, 희소 메모리는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-resource-binding[큐 연산] `vkQueueBindSparse()` 를 통해 바인딩됩니다. 이 방법의 가장 큰 장점은 애플리케이션의 수명이 다할 때까지 희소 리소스에 메모리를 다시 바인딩할 수 있다는 것입니다.
+`vkBindBufferMemory()` 또는 `vkBindImageMemory()` 를 호출하는 일반 리소스와 달리, 희소 메모리는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory-resource-binding[큐 연산] `vkQueueBindSparse()` 를 통해 바인딩됩니다. 이 방법의 가장 큰 장점은 애플리케이션의 수명이 다할 때까지 희소 리소스에 메모리를 다시 바인딩할 수 있다는 것입니다.
 
 이를 위해 애플리케이션에서 몇 가지 추가 고려 사항이 필요하다는 점에 유의해야 합니다. 애플리케이션은 다른 큐가 바인딩 변경과 동시에 메모리 범위에 접근하지 못하도록 보장하기 위해 **동기화 프리미티브를 사용해야 합니다**. 또한, `vkFreeMemory()` 로 `VkDeviceMemory` 객체를 해제해도 메모리 객체에 바인딩된 리소스(또는 리소스 영역)는 바인딩 **해제되지 않습니다**. 애플리케이션은 해제된 메모리에 바인딩된 리소스에 접근해서는 안 됩니다.
 
@@ -33,7 +33,7 @@ image::../../../chapters/images/sparse_resources_buffer.png[sparse_resources_buf
 
 ==== Mip Tail Regions
 
-희소 이미지를 사용하여 Mip 레벨을 개별적으로 업데이트하려면 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#sparsememory-miptail[mip tail region]이 생성됩니다. 이 사양서에는 다이어그램에서 발생할 수 있는 다양한 예제를 설명합니다.
+희소 이미지를 사용하여 Mip 레벨을 개별적으로 업데이트하려면 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#sparsememory-miptail[mip tail region]이 생성됩니다. 이 사양서에는 다이어그램에서 발생할 수 있는 다양한 예제를 설명합니다.
 
 ==== 기본 희소 리소스 예제
 

--- a/lang/kor/chapters/spirv_extensions.adoc
+++ b/lang/kor/chapters/spirv_extensions.adoc
@@ -14,7 +14,7 @@ SPIR-V는 중간 언어이지 API가 아니라는 것을 잊어서는 안 됩니
 
 == SPIR-V 확장 기능 예제
 
-이 예제에서는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_8bit_storage.html[VK_KHR_8bit_storage] 와 link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage]를 사용하여 `UniformAndStorageBuffer8BitAccess` 기능을 공개합니다. 다음은 SPIR-V의 디스어셈블리 모습입니다:
+이 예제에서는 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_8bit_storage.html[VK_KHR_8bit_storage] 와 link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage]를 사용하여 `UniformAndStorageBuffer8BitAccess` 기능을 공개합니다. 다음은 SPIR-V의 디스어셈블리 모습입니다:
 
 [source,swift]
 ----
@@ -37,11 +37,11 @@ OpExtension  "SPV_KHR_8bit_storage"
 
 쉐이더 기능에 따라 필요한 `OpExtension` 또는 `OpCapability` 가 하나만 있을 수 있습니다. 이 예제에서 `UniformAndStorageBuffer8BitAccess` 는 link:http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_8bit_storage.html[SPV_KHR_8bit_storage] 확장 기능의 일부입니다.
 
-SPIR-V 확장이 지원되는지 확인하려면 Vulkan 사양서에서 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-extensions[지원되는 SPIR-V 확장 기능 표]를 참조하세요.
+SPIR-V 확장이 지원되는지 확인하려면 Vulkan 사양서에서 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-extensions[지원되는 SPIR-V 확장 기능 표]를 참조하세요.
 
 image::../../../chapters/images/spirv_extensions_8bit_extension.png[spirv_extensions_8bit_extension]
 
-또한 Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-capabilities[지원되는 SPIR-V 기능(capabilites) 표]를 참고하세요.
+또한 Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-capabilities[지원되는 SPIR-V 기능(capabilites) 표]를 참고하세요.
 
 image::../../../chapters/images/spirv_extensions_8bit_capability.png[spirv_extensions_8bit_capability]
 

--- a/lang/kor/chapters/synchronization.adoc
+++ b/lang/kor/chapters/synchronization.adoc
@@ -8,7 +8,7 @@ ifndef::images[:images: images/]
 [[synchronization]]
 = 동기화
 
-동기화는 Vulkan을 사용할 때 가장 강력하지만 가장 복잡한 부분 중 하나입니다. 이제 애플리케이션 개발자는 다양한 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#synchronization[Vulkan 동기화 기본 요소]를 사용하여 동기화를 관리할 책임이 있습니다. 동기화를 부적절하게 사용하면 찾기 어려운 버그가 발생할 수 있을 뿐만 아니라 GPU가 불필요하게 idle 상태가 되어 성능이 저하될 수 있습니다.
+동기화는 Vulkan을 사용할 때 가장 강력하지만 가장 복잡한 부분 중 하나입니다. 이제 애플리케이션 개발자는 다양한 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#synchronization[Vulkan 동기화 기본 요소]를 사용하여 동기화를 관리할 책임이 있습니다. 동기화를 부적절하게 사용하면 찾기 어려운 버그가 발생할 수 있을 뿐만 아니라 GPU가 불필요하게 idle 상태가 되어 성능이 저하될 수 있습니다.
 
 크로노스 그룹에서 제공하는 link:https://github.com/KhronosGroup/Vulkan-Docs/wiki/Synchronization-Examples[예제 세트]와 link:https://www.khronos.org/blog/understanding-vulkan-synchronization[Vulkan 동기화 이해] 블로그에서 일부 동기화 프리미티브의 사용법을 확인할 수 있습니다. 지난 Vulkan talks에서 Tobias Hector의 프레젠테이션도 있습니다: link:https://www.khronos.org/assets/uploads/developers/library/2017-vulkan-devu-vancouver/009%20-%20Synchronization%20-%20Keeping%20Your%20Device%20Fed.pdf[part 1 slides] (link:https://www.youtube.com/watch?v=YkJ4hKCPjm0[video]) 및 link:https://www.khronos.org/assets/uploads/developers/library/2018-vulkanised/06-Keeping%20Your%20Device%20Fed%20v4_Vulkanised2018.pdf[part 2 slides] (link:https://www.youtube.com/watch?v=5GDg4OxkSEc[video]).
 
@@ -22,7 +22,7 @@ image::../../../chapters/images/synchronization_overview.png[synchronization_ove
 
 == 파이프라인 장벽(Pipeline Barriers)
 
-link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#synchronization-pipeline-barriers[파이프라인 장벽]은 커맨드 버퍼가 실행될 때 어떤 파이프라인 스테이지가 이전 파이프라인 스테이지를 기다려야 하는지 제어합니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#synchronization-pipeline-barriers[파이프라인 장벽]은 커맨드 버퍼가 실행될 때 어떤 파이프라인 스테이지가 이전 파이프라인 스테이지를 기다려야 하는지 제어합니다.
 
 image::../../../chapters/images/synchronization_pipeline_barrieres.png[synchronization_pipeline_barrieres.png]
 

--- a/lang/kor/chapters/threading.adoc
+++ b/lang/kor/chapters/threading.adoc
@@ -10,13 +10,13 @@ ifndef::images[:images: images/]
 
 Vulkan과 OpenGL의 가장 큰 차이점 중 하나는 Vulkan이 단일 스레드 상태 머신 시스템에 국한되지 않는다는 점입니다. 애플리케이션에서 스레드를 구현하기 전에 먼저 Vulkan에서 스레드가 어떻게 작동하는지 이해하는 것이 중요합니다.
 
-Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#fundamentals-threadingbehavior[스레딩 동작 섹션]에서는 애플리케이션이 Vulkan의 모든 _외부적으로 동기화된_ 요소를 관리하는 방법을 자세히 설명합니다. Vulkan의 멀티스레딩은 호스트 측 스케일링만 제공하므로, 장치와 상호작용하는 모든 것이 여전히 xref:{chapters}synchronization.adoc#synchronization[올바르게 동기화된] 상태여야 한다는 점이 중요합니다.
+Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-threadingbehavior[스레딩 동작 섹션]에서는 애플리케이션이 Vulkan의 모든 _외부적으로 동기화된_ 요소를 관리하는 방법을 자세히 설명합니다. Vulkan의 멀티스레딩은 호스트 측 스케일링만 제공하므로, 장치와 상호작용하는 모든 것이 여전히 xref:{chapters}synchronization.adoc#synchronization[올바르게 동기화된] 상태여야 한다는 점이 중요합니다.
 
 Vulkan 구현에서는 멀티스레드를 도입하는 것은 예상되지 않기 때문에 앱이 멀티 CPU 성능을 요구하는 경우 앱이 스레드 관리를 담당하게 됩니다.
 
 == 커맨드 풀
 
-link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#commandbuffers-pools[커맨드 풀]은 여러 스레드에 걸쳐 커맨드 버퍼를 기록할 수 있는 시스템입니다. 하나의 커맨드 풀은 _외부적으로 동기화_ 되어야 하며 여러 스레드에서 동시에 접근해서는 안 됩니다. 호스트 스레드마다 독립적인 커맨드 풀을 사용함으로써 애플리케이션은 비용이 많이 드는 잠금 장치 없이 여러 커맨드 버퍼를 병렬로 생성할 수 있습니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#commandbuffers-pools[커맨드 풀]은 여러 스레드에 걸쳐 커맨드 버퍼를 기록할 수 있는 시스템입니다. 하나의 커맨드 풀은 _외부적으로 동기화_ 되어야 하며 여러 스레드에서 동시에 접근해서는 안 됩니다. 호스트 스레드마다 독립적인 커맨드 풀을 사용함으로써 애플리케이션은 비용이 많이 드는 잠금 장치 없이 여러 커맨드 버퍼를 병렬로 생성할 수 있습니다.
 
 상대적으로 가벼운 스레드가 제출을 처리하면 커맨드 버퍼를 여러 스레드에 기록할 수 있다는 아이디어 입니다.
 
@@ -26,4 +26,4 @@ image::../../../chapters/images/threading_command_buffers.png[threading_command_
 
 == 디스크립터 풀
 
-link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#VkDescriptorPool[디스크립터 풀]은 디스크립터 세트를 할당, 해제, 재설정 및 업데이트하는 데 사용됩니다. 여러 개의 디스크립터 풀을 만들면 각 애플리케이션 호스트 스레드가 각 디스크립터 풀의 디스크립터 세트를 동시에 관리할 수 있습니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkDescriptorPool[디스크립터 풀]은 디스크립터 세트를 할당, 해제, 재설정 및 업데이트하는 데 사용됩니다. 여러 개의 디스크립터 풀을 만들면 각 애플리케이션 호스트 스레드가 각 디스크립터 풀의 디스크립터 세트를 동시에 관리할 수 있습니다.

--- a/lang/kor/chapters/validation_overview.adoc
+++ b/lang/kor/chapters/validation_overview.adoc
@@ -15,7 +15,7 @@ ifndef::images[:images: images/]
 
 == 유효한 사용(Valid Usage: VU)
 
-**VU**는 명시적으로 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-validusage[Vulkan 사양서에서 다음과 같이 정의됩니다]:
+**VU**는 명시적으로 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-validusage[Vulkan 사양서에서 다음과 같이 정의됩니다]:
 
 [NOTE]
 ====
@@ -36,7 +36,7 @@ ifndef::images[:images: images/]
 
 `VUID` 는 각 유효한 사용 사례에 부여된 고유 ID입니다. 이를 통해 사양서에서 유효한 사용법을 쉽게 찾을 수 있습니다.
 
-`VUID-vkBindImageMemory-memoryOffset-01046` 을 예로 들면, HTML 버전의 사양서(link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046[vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046])에서 앵커에 VUID를 추가하는 것만큼 간단하며 바로 VUID로 이동할 수 있습니다.
+`VUID-vkBindImageMemory-memoryOffset-01046` 을 예로 들면, HTML 버전의 사양서(link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046[vkspec.html#VUID-vkBindImageMemory-memoryOffset-01046])에서 앵커에 VUID를 추가하는 것만큼 간단하며 바로 VUID로 이동할 수 있습니다.
 
 [[khronos-validation-layer]]
 == 크로노스 유효성 검사 레이어
@@ -63,7 +63,7 @@ Vulkan은 오류 검사를 수행하지 않으므로, 개발 시 link:https://gi
 
 === 예제 1 - 암시적 유효한 사용법
 
-이 예제는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-implicit-validity[암시적 VU]가 트리거되는 경우를 보여줍니다. VUID 끝에는 숫자가 없습니다.
+이 예제는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-implicit-validity[암시적 VU]가 트리거되는 경우를 보여줍니다. VUID 끝에는 숫자가 없습니다.
 
 [source]
 ----
@@ -77,8 +77,8 @@ html/vkspec.html#VUID-vkBindBufferMemory-memory-parameter)
   * 가장 먼저 눈에 띄는 것은 메시지에서 VUID가 가장 먼저 나열된다는 점입니다(`VUID-vkBindBufferMemory-memory-parameter`)
   ** 메시지 말미에 사양서에 있는 VUID로 연결되는 링크도 있습니다
   * `The Vulkan spec states:` 은 사양서에서 인용한 VUID 입니다.
-  * The `VK_OBJECT_TYPE_INSTANCE` 는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#_debugging[VkObjectType] 입니다
-  * `Invalid VkDeviceMemory Object 0x60000000006` 는 어떤 `VkDeviceMemory` 핸들이 오류의 원인인지 보여주는 데 도움을 주는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fundamentals-objectmodel-overview[디스패치 가능한 핸들] 입니다.
+  * The `VK_OBJECT_TYPE_INSTANCE` 는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#_debugging[VkObjectType] 입니다
+  * `Invalid VkDeviceMemory Object 0x60000000006` 는 어떤 `VkDeviceMemory` 핸들이 오류의 원인인지 보여주는 데 도움을 주는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fundamentals-objectmodel-overview[디스패치 가능한 핸들] 입니다.
 
 === 예제 2 - 명시적 유효한 사용법
 
@@ -154,7 +154,7 @@ endif::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
 
 == 특수 용도 태그
 
-link:https://vulkan.lunarg.com/doc/sdk/latest/windows/best_practices.html[레이어 모범 사례]는 애플리케이션이 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-specialuse[특수 용도 태그]가 있는 확장 기능을 사용하려고 할 때 경고를 표시합니다. 이러한 확장 기능의 예로서 에뮬레이션 레이어 전용으로 설계된 xref:{chapters}extensions/translation_layer_extensions.adoc#vk_ext_transform_feedback[VK_EXT_transform_feedback]이 있습니다. 애플리케이션의 사용 목적이 특수 용도에 해당하는 경우 아래와 같은 접근 방식을 사용하면 경고를 무시할 수 있습니다.
+link:https://vulkan.lunarg.com/doc/sdk/latest/windows/best_practices.html[레이어 모범 사례]는 애플리케이션이 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-specialuse[특수 용도 태그]가 있는 확장 기능을 사용하려고 할 때 경고를 표시합니다. 이러한 확장 기능의 예로서 에뮬레이션 레이어 전용으로 설계된 xref:{chapters}extensions/translation_layer_extensions.adoc#vk_ext_transform_feedback[VK_EXT_transform_feedback]이 있습니다. 애플리케이션의 사용 목적이 특수 용도에 해당하는 경우 아래와 같은 접근 방식을 사용하면 경고를 무시할 수 있습니다.
 
 `VK_EXT_debug_report` 로 특수 용도 경고 무시하기
 

--- a/lang/kor/chapters/versions.adoc
+++ b/lang/kor/chapters/versions.adoc
@@ -8,13 +8,13 @@ ifndef::images[:images: images/]
 [[versions]]
 = 버전(Versions)
 
-Vulkan은 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions-versionnumbers[메이저(major), 마이너(minor), 패치(patch)] 버전관리 시스템으로 작동합니다. 현재 Vulkan에는 서로 하위호환되는 3개의 부 버전 릴리즈 (1.0, 1.1, 1.2, 1.3)가 있습니다. 애플리케이션은 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkEnumerateInstanceVersion[vkEnumerateInstanceVersion]을 사용하여 어떤 버전의 Vulkan 인스턴스가 지원되는지 확인할 수 있습니다. 지원되는 버전을쿼리하고 확인하는 방법에 대한 LunarG의 link:https://www.lunarg.com/wp-content/uploads/2019/02/Vulkan-1.1-Compatibility-Statement_01_19.pdf[백서(white paper)]도 있습니다. 부 버전에서 작업할 때 주의해야 할 몇 가지 미묘한 사항이 있습니다.
+Vulkan은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-versionnumbers[메이저(major), 마이너(minor), 패치(patch)] 버전관리 시스템으로 작동합니다. 현재 Vulkan에는 서로 하위호환되는 3개의 부 버전 릴리즈 (1.0, 1.1, 1.2, 1.3)가 있습니다. 애플리케이션은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkEnumerateInstanceVersion[vkEnumerateInstanceVersion]을 사용하여 어떤 버전의 Vulkan 인스턴스가 지원되는지 확인할 수 있습니다. 지원되는 버전을쿼리하고 확인하는 방법에 대한 LunarG의 link:https://www.lunarg.com/wp-content/uploads/2019/02/Vulkan-1.1-Compatibility-Statement_01_19.pdf[백서(white paper)]도 있습니다. 부 버전에서 작업할 때 주의해야 할 몇 가지 미묘한 사항이 있습니다.
 
 == 인스턴스와 장치
 
 인스턴스 레벨 버전과 디바이스 레벨 버전에는 차이가 있다는 점이 중요합니다. 로더와 구현이 서로 다른 버전을 지원할 수 있습니다.
 
-Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions-queryingversionsupport[버전 지원 쿼리] 섹션에서는 인스턴스 및 장치 레벨에서 지원되는 버전을 쿼리하는 방법에 대해 자세히 설명합니다.
+Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-queryingversionsupport[버전 지원 쿼리] 섹션에서는 인스턴스 및 장치 레벨에서 지원되는 버전을 쿼리하는 방법에 대해 자세히 설명합니다.
 
 == 헤더
 
@@ -24,7 +24,7 @@ Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/1.3/html/vksp
 
 == 확장 기능
 
-Vulkan의 마이너 버전 사이에서 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#versions-1.1[일부 확장 기능]은 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions[코어 버전]으로 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-compatibility-promotions[승격됩니다]. Vulkan의 최신 마이너 버전을 대상으로 하는 애플리케이션은 인스턴스 및 장치 생성 시 새로 승격된 확장 기능을 활성화할 필요가 없습니다. 그러나 애플리케이션이 이전 버전과의 호환성을 유지하려면 확장 기능을 활성화해야 합니다.
+Vulkan의 마이너 버전 사이에서 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.1[일부 확장 기능]은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions[코어 버전]으로 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotions[승격됩니다]. Vulkan의 최신 마이너 버전을 대상으로 하는 애플리케이션은 인스턴스 및 장치 생성 시 새로 승격된 확장 기능을 활성화할 필요가 없습니다. 그러나 애플리케이션이 이전 버전과의 호환성을 유지하려면 확장 기능을 활성화해야 합니다.
 
 각 버전의 새로운 기능에 대한 요약은 xref:{chapters}vulkan_release_summary.adoc#vulkan-release-summary[Vulkan 랄리즈 요약]을 확인하세요.
 
@@ -54,17 +54,17 @@ Vulkan 1.0 구현에서 `vkGetPhysicalDeviceFeatures2KHR` 함수는 확장 기�
 
 == 기능(Features)
 
-마이너 버전 간에 몇 가지 기능 비트가 추가, 제거, 선택/필수 사항으로 변경될 수 있습니다. 변경된 기능에 대한 자세한 내용은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions[핵심 개정 사항] 섹션에 설명되어 있습니다.
+마이너 버전 간에 몇 가지 기능 비트가 추가, 제거, 선택/필수 사항으로 변경될 수 있습니다. 변경된 기능에 대한 자세한 내용은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions[핵심 개정 사항] 섹션에 설명되어 있습니다.
 
-Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-requirements[기능 요구사항] 섹션에서 마이너 버전 구현에 필요한 기능 목록을 확인할 수 있습니다.
+Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-requirements[기능 요구사항] 섹션에서 마이너 버전 구현에 필요한 기능 목록을 확인할 수 있습니다.
 
 == 제한
 
-현재 Vulkan의 모든 버전은 최소/최대 제한 요구 사항을 동일하게 공유하지만, 변경 사항이 있을 경우 Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#limits-minmax[제한 요구사항] 섹션에 기재됩니다.
+현재 Vulkan의 모든 버전은 최소/최대 제한 요구 사항을 동일하게 공유하지만, 변경 사항이 있을 경우 Vulkan 사양서의 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#limits-minmax[제한 요구사항] 섹션에 기재됩니다.
 
 == SPIR-V
 
-모든 Vulkan의 마이너 버전은 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#spirvenv[지원해야 하는 SPIR-V] 버전에 매핑됩니다.
+모든 Vulkan의 마이너 버전은 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv[지원해야 하는 SPIR-V] 버전에 매핑됩니다.
 
   * Vulkan 1.0은 SPIR-V 1.0 을 지원합니다
   * Vulkan 1.1은 SPIR-V 1.3 이하를 지원합니다

--- a/lang/kor/chapters/vertex_input_data_processing.adoc
+++ b/lang/kor/chapters/vertex_input_data_processing.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[vertex-input-data-processing]]
 = 정점 입력 데이터 처리
 
-이 장에서는 그래픽스 파이프라인을 사용할 때 애플리케이션이 어떻게 데이터를 정점 쉐이더에 매핑하는지에 대한 깊은 이해를 위해 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex[사양서의 고정 함수 정점 처리 챕터]의 개요를 설명합니다.
+이 장에서는 그래픽스 파이프라인을 사용할 때 애플리케이션이 어떻게 데이터를 정점 쉐이더에 매핑하는지에 대한 깊은 이해를 위해 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fxvertex[사양서의 고정 함수 정점 처리 챕터]의 개요를 설명합니다.
 
 Vulkan은 다양한 방식으로 사용할 수 있는 도구라는 점을 기억하세요. 다음은 정점 데이터를 어떻게 배치**할 수 있는 지**에 대한 교육 목적의 예시입니다.
 
@@ -316,7 +316,7 @@ ____
 
 == 컴포넌트 할당
 
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fxvertex-attrib-location[사양서]에서 `Component` 할당에 대해 더 자세히 설명합니다. 다음은 주제에 대한 일반적인 개요입니다.
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#fxvertex-attrib-location[사양서]에서 `Component` 할당에 대해 더 자세히 설명합니다. 다음은 주제에 대한 일반적인 개요입니다.
 
 
 === 컴포넌트 채우기
@@ -327,7 +327,7 @@ ____
 `VK_FORMAT_R32G32B32_SFLOAT` 에는 3개의 컴포넌트가 있는 반면 `vec2` 에는 2개만 있습니다
 ____
 
-그 반대의 경우 사양에는 누락된 컴포넌트를 확장하는 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-conversion-to-rgba[방법을 보여주는 표가 있습니다.]
+그 반대의 경우 사양에는 누락된 컴포넌트를 확장하는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#textures-conversion-to-rgba[방법을 보여주는 표가 있습니다.]
 
 
 이는 다음과 같은 예제를 의미합니다

--- a/lang/kor/chapters/vulkan_cts.adoc
+++ b/lang/kor/chapters/vulkan_cts.adoc
@@ -15,4 +15,4 @@ link:https://github.com/KhronosGroup/VK-GL-CTS/tree/master/external/vulkancts[Vu
 
 image::../../../chapters/images/vulkan_cts_overview.png[vulkan_cts_overview.png]
 
-애플리케이션은 `VK_KHR_driver_properties` 확장 기능을 통해 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] 프로퍼티를 사용하여 구현에 전달된 CTS 버전을 쿼리할 수 있습니다(Vulkan 1.2에서 코어로 승격됨).
+애플리케이션은 `VK_KHR_driver_properties` 확장 기능을 통해 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkConformanceVersion[VkConformanceVersion] 프로퍼티를 사용하여 구현에 전달된 CTS 버전을 쿼리할 수 있습니다(Vulkan 1.2에서 코어로 승격됨).

--- a/lang/kor/chapters/vulkan_release_summary.adoc
+++ b/lang/kor/chapters/vulkan_release_summary.adoc
@@ -8,7 +8,7 @@ ifndef::images[:images: images/]
 [[vulkan-release-summary]]
 = Vulkan Release 요약
 
-Vulkan의 각 마이너 릴리즈 버전은 서로 다른 확장 기능 세트를 코어로 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-compatibility-promotion[승격]했습니다. 즉, 애플리케이션이 최소한 해당 Vulkan 버전을 요청하는 경우(해당 버전이 구현에서 지원되는 경우) 승격된 기능을 사용하기 위해 확장 기능을 활성화할 필요가 없데 되었습니다.
+Vulkan의 각 마이너 릴리즈 버전은 서로 다른 확장 기능 세트를 코어로 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-compatibility-promotion[승격]했습니다. 즉, 애플리케이션이 최소한 해당 Vulkan 버전을 요청하는 경우(해당 버전이 구현에서 지원되는 경우) 승격된 기능을 사용하기 위해 확장 기능을 활성화할 필요가 없데 되었습니다.
 
 다음 요약에는 각 코어 버전에 추가된 확장 기능 목록과 추가된 이유가 포함되어 있습니다. 이 목록은 Vulkan 사양서에서 가져온 것이지만 링크는 Vulkan 가이드의 다양한 부분으로 이동됩니다
 
@@ -16,7 +16,7 @@ Vulkan의 각 마이너 릴리즈 버전은 서로 다른 확장 기능 세트�
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.1[Vulkan Spec Section]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.1[Vulkan Spec Section]
 ====
 
 Vulkan 1.1은 2018년 3월 7일에 릴리즈되었습니다.
@@ -40,7 +40,7 @@ Vulkan 1.1은 2018년 3월 7일에 릴리즈되었습니다.
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance1]
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance2]
   * xref:{chapters}extensions/cleanup.adoc#maintenance-extensions[VK_KHR_maintenance3]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_multiview.html#_description[VK_KHR_multiview]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_multiview.html#_description[VK_KHR_multiview]
   * xref:{chapters}shader_memory_layout.adoc#VK_KHR_relaxed_block_layout[VK_KHR_relaxed_block_layout]
   * xref:{chapters}extensions/VK_KHR_sampler_ycbcr_conversion.adoc#VK_KHR_sampler_ycbcr_conversion[VK_KHR_sampler_ycbcr_conversion]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_draw_parameters[VK_KHR_shader_draw_parameters]
@@ -51,15 +51,15 @@ Vulkan 1.1은 2018년 3월 7일에 릴리즈되었습니다.
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.2[Vulkan Spec Section]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.2[Vulkan Spec Section]
 ====
 
 Vulkan 1.2는 2020년 1월 15일에 릴리즈되었습니다
 
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_8bit_storage[VK_KHR_8bit_storage]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_buffer_device_address.html#_description[VK_KHR_buffer_device_address]
   * xref:{chapters}extensions/cleanup.adoc#pnext-expansions[VK_KHR_create_renderpass2]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_depth_stencil_resolve.html#_description[VK_KHR_depth_stencil_resolve]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_depth_stencil_resolve.html#_description[VK_KHR_depth_stencil_resolve]
   * xref:{chapters}extensions/VK_KHR_draw_indirect_count.adoc#VK_KHR_draw_indirect_count[VK_KHR_draw_indirect_count]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_driver_properties[VK_KHR_driver_properties]
   * xref:{chapters}extensions/VK_KHR_image_format_list.adoc#VK_KHR_image_format_list[VK_KHR_image_format_list]
@@ -85,7 +85,7 @@ Vulkan 1.2는 2020년 1월 15일에 릴리즈되었습니다
 
 [NOTE]
 ====
-link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#versions-1.3[Vulkan Spec Section]
+link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#versions-1.3[Vulkan Spec Section]
 ====
 
 Vulkan 1.3은 2022년 1월 25일에 릴리즈되었습니다
@@ -94,7 +94,7 @@ Vulkan 1.3은 2022년 1월 25일에 릴리즈되었습니다
   * link:https://www.khronos.org/blog/streamlining-render-passes[VK_KHR_dynamic_rendering]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_format_feature_flags2[VK_KHR_format_feature_flags2]
   * xref:{chapters}extensions/cleanup.adoc#VK_KHR_maintenance4[VK_KHR_maintenance4]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_integer_dot_product.html#_description[VK_KHR_shader_integer_dot_product]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_shader_integer_dot_product.html#_description[VK_KHR_shader_integer_dot_product]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_non_semantic_info[VK_KHR_shader_non_semantic_info]
   * xref:{chapters}extensions/shader_features.adoc#VK_KHR_shader_terminate_invocation[VK_KHR_shader_terminate_invocation]
   * xref:{chapters}extensions/VK_KHR_synchronization2.adoc[VK_KHR_synchronization2]
@@ -103,12 +103,12 @@ Vulkan 1.3은 2022년 1월 25일에 릴리즈되었습니다
   * xref:{chapters}dynamic_state.adoc#states-that-are-dynamic[VK_EXT_extended_dynamic_state]
   * xref:{chapters}dynamic_state.adoc#states-that-are-dynamic[VK_EXT_extended_dynamic_state2]
   * xref:{chapters}extensions/VK_EXT_inline_uniform_block.adoc#VK_EXT_inline_uniform_block[VK_EXT_inline_uniform_block]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_cache_control.html#_description[VK_EXT_pipeline_creation_cache_control]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_feedback.html#_description[VK_EXT_pipeline_creation_feedback]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_private_data.html#_description[VK_EXT_private_data]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_pipeline_creation_cache_control.html#_description[VK_EXT_pipeline_creation_cache_control]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_pipeline_creation_feedback.html#_description[VK_EXT_pipeline_creation_feedback]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_private_data.html#_description[VK_EXT_private_data]
   * xref:{chapters}extensions/shader_features.adoc#VK_EXT_shader_demote_to_helper_invocation[VK_EXT_shader_demote_to_helper_invocation]
   * xref:{chapters}subgroups.adoc#VK_EXT_subgroup_size_control[VK_EXT_subgroup_size_control]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_texel_buffer_alignment.html#_description[VK_EXT_texel_buffer_alignment]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_texture_compression_astc_hdr.html#_description[VK_EXT_texture_compression_astc_hdr]
-  * link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_tooling_info.html#_description[VK_EXT_tooling_info]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_texel_buffer_alignment.html#_description[VK_EXT_texel_buffer_alignment]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_texture_compression_astc_hdr.html#_description[VK_EXT_texture_compression_astc_hdr]
+  * link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_tooling_info.html#_description[VK_EXT_tooling_info]
   * xref:{chapters}extensions/cleanup.adoc#VK_EXT_4444_formats-and-VK_EXT_ycbcr_2plane_444_formats[VK_EXT_ycbcr_2plane_444_formats]

--- a/lang/kor/chapters/what_is_spirv.adoc
+++ b/lang/kor/chapters/what_is_spirv.adoc
@@ -12,14 +12,14 @@ ifndef::images[:images: images/]
 SPIR-V에 대한 자세한 내용은 link:https://github.com/KhronosGroup/SPIRV-Guide[SPIRV-Guide]를 참조하세요
 ====
 
-link:https://registry.khronos.org/SPIR-V/[SPIR-V]는 그래픽 쉐이더 스테이지와 컴퓨트 커널을 위한 바이너리 중간 표현입니다. Vulkan에서는 애플리케이션에서 쉐이더를 GLSL 또는 xref:{chapters}hlsl.adoc[HLSL]과 같은 고수준 쉐이딩 언어를 쓸수 있지만, link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#vkCreateShaderModule[vkCreateShaderModule]을 사용할 때는 SPIR-V 바이너리가 필요합니다. 크로노스에는 SPIR-V와 그 장점 및 표현에 대한 높은 수준의 설명에 대한 link:https://registry.khronos.org/SPIR-V/papers/WhitePaper.pdf[백서(white paper)]가 있습니다. Vulkan DevDay 2016에서 두 가지 훌륭한 크로노스 프레젠테이션을 link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/3-Intro-to-spir-v-shaders.pdf[이곳]과 link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/4-Using-spir-v-with-spirv-cross.pdf[이곳]에서 볼 수 있습니다.
+link:https://registry.khronos.org/SPIR-V/[SPIR-V]는 그래픽 쉐이더 스테이지와 컴퓨트 커널을 위한 바이너리 중간 표현입니다. Vulkan에서는 애플리케이션에서 쉐이더를 GLSL 또는 xref:{chapters}hlsl.adoc[HLSL]과 같은 고수준 쉐이딩 언어를 쓸수 있지만, link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateShaderModule[vkCreateShaderModule]을 사용할 때는 SPIR-V 바이너리가 필요합니다. 크로노스에는 SPIR-V와 그 장점 및 표현에 대한 높은 수준의 설명에 대한 link:https://registry.khronos.org/SPIR-V/papers/WhitePaper.pdf[백서(white paper)]가 있습니다. Vulkan DevDay 2016에서 두 가지 훌륭한 크로노스 프레젠테이션을 link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/3-Intro-to-spir-v-shaders.pdf[이곳]과 link:https://www.khronos.org/assets/uploads/developers/library/2016-vulkan-devday-uk/4-Using-spir-v-with-spirv-cross.pdf[이곳]에서 볼 수 있습니다.
 (link:https://www.youtube.com/watch?v=XRpVwdduzgU[두 프레젠테이션의 동영상]).
 
 == SPIR-V 인터페이스 및 기능
 
-Vulkan에는 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#interfaces[Vulkan이 SPIR-V 쉐이더와 인터페이스하는 방법]을 정의하는 전체 섹션이 있습니다. SPIR-V와의 인터페이스는쉐이더를 함께 컴파일할 때 파이프라인 생성 중에 가장 유효하게 사용됩니다.
+Vulkan에는 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces[Vulkan이 SPIR-V 쉐이더와 인터페이스하는 방법]을 정의하는 전체 섹션이 있습니다. SPIR-V와의 인터페이스는쉐이더를 함께 컴파일할 때 파이프라인 생성 중에 가장 유효하게 사용됩니다.
 
-SPIR-V는 Vulkan뿐만 아니라 다른 대상도 지원하기 때문에 많은 기능을 가지고 있습니다. Vulkan에 필요한 지원 기능을 확인하려면 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#spirvenv-capabilities[부록]을 참조하세요. Vulkan의 일부 확장 및 기능은 일부 SPIR-V 기능의 지원 여부를 확인하기 위해 설계되었습니다.
+SPIR-V는 Vulkan뿐만 아니라 다른 대상도 지원하기 때문에 많은 기능을 가지고 있습니다. Vulkan에 필요한 지원 기능을 확인하려면 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#spirvenv-capabilities[부록]을 참조하세요. Vulkan의 일부 확장 및 기능은 일부 SPIR-V 기능의 지원 여부를 확인하기 위해 설계되었습니다.
 
 == 컴파일러
 

--- a/lang/kor/chapters/what_is_vulkan.adoc
+++ b/lang/kor/chapters/what_is_vulkan.adoc
@@ -16,7 +16,7 @@ Vulkan은 회사나 언어가 아니라 개발자가 크로스 플랫폼 및 크
 
 == Vulkan의 핵심
 
-본질적으로 Vulkan은 적합한 하드웨어 구현이 따르는 link:https://registry.khronos.org/vulkan/#apispecs[API 사양]입니다. 공개된 사양은 link:https://github.com/KhronosGroup/Vulkan-Docs[Vulkan-Doc]에 있는 Vulkan Specification 저장소의 공식 공개 사본에 있는 link:https://github.com/KhronosGroup/Vulkan-Docs/blob/main/xml/vk.xml[./xml/vk.xml] Vulkan Registry 파일에서 생성됩니다. 또한 link:https://registry.khronos.org/vulkan/specs/1.3/registry.html[XML 스키마]에 대한 문서도 제공됩니다.
+본질적으로 Vulkan은 적합한 하드웨어 구현이 따르는 link:https://registry.khronos.org/vulkan/#apispecs[API 사양]입니다. 공개된 사양은 link:https://github.com/KhronosGroup/Vulkan-Docs[Vulkan-Doc]에 있는 Vulkan Specification 저장소의 공식 공개 사본에 있는 link:https://github.com/KhronosGroup/Vulkan-Docs/blob/main/xml/vk.xml[./xml/vk.xml] Vulkan Registry 파일에서 생성됩니다. 또한 link:https://registry.khronos.org/vulkan/specs/latest/registry.html[XML 스키마]에 대한 문서도 제공됩니다.
 
 크로노스 그룹은 Vulkan 사양과 함께 개발자가 Vulkan API와 인터페이스하는 데 사용할 수 있는 link:https://registry.khronos.org/vulkan/#apiregistry[API Registry]에서 생성된 link:https://www.open-std.org/jtc1/sc22/wg14/www/standards[C99] link:https://github.com/KhronosGroup/Vulkan-Headers/tree/main/include/vulkan[header files]을 공개합니다.
 

--- a/lang/kor/chapters/what_vulkan_can_do.adoc
+++ b/lang/kor/chapters/what_vulkan_can_do.adoc
@@ -37,16 +37,16 @@ link:https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_process
 
 레이 트레이싱은 빛의 물리적 동작을 시뮬레이션하는 개념을 기반으로 하는 대체 렌더링 기법입니다.
 
-레이 트레이싱에 대한 크로스 벤더 API 지원이 1.2.162 사양에서 확장 기능 세트가 Vulkan에 추가되었습니다. 주로 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_ray_query[`VK_KHR_ray_query`], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`]가 이에 해당합니다.
+레이 트레이싱에 대한 크로스 벤더 API 지원이 1.2.162 사양에서 확장 기능 세트가 Vulkan에 추가되었습니다. 주로 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_ray_tracing_pipeline[`VK_KHR_ray_tracing_pipeline`], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_ray_query[`VK_KHR_ray_query`], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_KHR_acceleration_structure[`VK_KHR_acceleration_structure`]가 이에 해당합니다.
 
 [NOTE]
 ====
-레이 트레이싱 구현을 공개하는 이전 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VK_NV_ray_tracing[NVIDIA 벤더 확장 기능]도 있습니다. 이 확장 기능은 제조사 간 확장 기능보다 먼저 출시되었습니다. 신규 개발의 경우 최신 KHR 확장 기능을 사용하는 것이 좋습니다.
+레이 트레이싱 구현을 공개하는 이전 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VK_NV_ray_tracing[NVIDIA 벤더 확장 기능]도 있습니다. 이 확장 기능은 제조사 간 확장 기능보다 먼저 출시되었습니다. 신규 개발의 경우 최신 KHR 확장 기능을 사용하는 것이 좋습니다.
 ====
 
 == Video
 
-link:https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-decode[Vulkan Video 확장 기능]을 통해 개발자는 하드웨어 가속 비디오 디코딩 기능을 실시간으로 사용할 수 있습니다. 이 기능은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_queue.html[VK_KHR_video_queue], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_queue.html[VK_KHR_video_decode_queue], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_h264.html[VK_KHR_video_decode_h264], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_video_decode_h265.html[VK_KHR_video_decode_h265] 확장 기능을 통해 공개됩니다.
+link:https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-decode[Vulkan Video 확장 기능]을 통해 개발자는 하드웨어 가속 비디오 디코딩 기능을 실시간으로 사용할 수 있습니다. 이 기능은 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_queue.html[VK_KHR_video_queue], link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_queue.html[VK_KHR_video_decode_queue], link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_h264.html[VK_KHR_video_decode_h264], link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_h265.html[VK_KHR_video_decode_h265] 확장 기능을 통해 공개됩니다.
 
 Vulkan Video는 애플리케이션에 비디오 처리 스케줄링, 동기화 및 메모리 활용에 대한 유연하고 세밀한 제어 기능을 제공한다는 Vulkan의 철학을 고수합니다.
 

--- a/lang/kor/chapters/wsi.adoc
+++ b/lang/kor/chapters/wsi.adoc
@@ -7,7 +7,7 @@ ifndef::images[:images: images/]
 [[wsi]]
 = 창 시스템 통합(Window System Integration, WSI)
 
-Vulkan API는 결과를 표시하지 않고 사용할 수 있으므로 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#wsi[선택적 Vulkan 확장 기능]을 사용하여 WSI를 제공합니다. 대부분의 구현에는 WSI 지원이 포함됩니다. WSI 설계는 각 플랫폼의 윈도우 메커니즘을 코어 Vulkan API에서 추상화하기 위해 만들어졌습니다.
+Vulkan API는 결과를 표시하지 않고 사용할 수 있으므로 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#wsi[선택적 Vulkan 확장 기능]을 사용하여 WSI를 제공합니다. 대부분의 구현에는 WSI 지원이 포함됩니다. WSI 설계는 각 플랫폼의 윈도우 메커니즘을 코어 Vulkan API에서 추상화하기 위해 만들어졌습니다.
 
 image::../../../chapters/images/wsi_setup.png[wsi_setup]
 
@@ -17,25 +17,25 @@ image::../../../chapters/images/wsi_setup.png[wsi_setup]
 
 Vulkan 서페이스를 지원하는 각 플랫폼은 플랫폼마다 고유의 API에서 `VkSurfaceKHR` 객체를 만드는 독자적인 방법을 가지고 있습니다.
 
-  * Android - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
-  * DirectFB - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
-  * Fuchsia - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
-  * iOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
-  * macOS - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
-  * Metal - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]
-  * VI - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateViSurfaceNN[vkCreateViSurfaceNN]
-  * Wayland - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkWaylandSurfaceCreateInfoKHR[vkWaylandSurfaceCreateInfoKHR]
-  * QNX - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateScreenSurfaceQNX.html[vkCreateScreenSurfaceQNX]
-  * Windows - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateWin32SurfaceKHR[vkCreateWin32SurfaceKHR]
-  * XCB - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateXcbSurfaceKHR[vkCreateXcbSurfaceKHR]
-  * Xlib - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateXlibSurfaceKHR[vkCreateXlibSurfaceKHR]
-  * Direct-to-Display - link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkCreateDisplayPlaneSurfaceKHR[vkCreateDisplayPlaneSurfaceKHR]
+  * Android - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateAndroidSurfaceKHR[vkCreateAndroidSurfaceKHR]
+  * DirectFB - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateDirectFBSurfaceEXT[vkCreateDirectFBSurfaceEXT]
+  * Fuchsia - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateImagePipeSurfaceFUCHSIA[vkCreateImagePipeSurfaceFUCHSIA]
+  * iOS - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateIOSSurfaceMVK[vkCreateIOSSurfaceMVK]
+  * macOS - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateMacOSSurfaceMVK[vkCreateMacOSSurfaceMVK]
+  * Metal - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateMetalSurfaceEXT[vkCreateMetalSurfaceEXT]
+  * VI - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateViSurfaceNN[vkCreateViSurfaceNN]
+  * Wayland - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkWaylandSurfaceCreateInfoKHR[vkWaylandSurfaceCreateInfoKHR]
+  * QNX - link:https://registry.khronos.org/vulkan/specs/latest/man/html/vkCreateScreenSurfaceQNX.html[vkCreateScreenSurfaceQNX]
+  * Windows - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateWin32SurfaceKHR[vkCreateWin32SurfaceKHR]
+  * XCB - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateXcbSurfaceKHR[vkCreateXcbSurfaceKHR]
+  * Xlib - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateXlibSurfaceKHR[vkCreateXlibSurfaceKHR]
+  * Direct-to-Display - link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkCreateDisplayPlaneSurfaceKHR[vkCreateDisplayPlaneSurfaceKHR]
 
-`VkSurfaceKHR` 이 생성되면 다양한 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfaceCapabilitiesKHR[기능], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfaceFormatsKHR[포맷], link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vkGetPhysicalDeviceSurfacePresentModesKHR[프레젠테이션 모드]를 쿼리할 수 있습니다.
+`VkSurfaceKHR` 이 생성되면 다양한 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfaceCapabilitiesKHR[기능], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfaceFormatsKHR[포맷], link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#vkGetPhysicalDeviceSurfacePresentModesKHR[프레젠테이션 모드]를 쿼리할 수 있습니다.
 
 == 스왑체인(Swapchain)
 
-`VkSwapchainKHR` 객체는 `VkImage` 객체 배열을 통해 렌더링 결과를 서페이스에 표시하는 기능을 제공합니다. 스왑체인의 다양한 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkPresentModeKHR[표시 모드]에 따라 표시 엔진이 구현되는 방식이 결정됩니다.
+`VkSwapchainKHR` 객체는 `VkImage` 객체 배열을 통해 렌더링 결과를 서페이스에 표시하는 기능을 제공합니다. 스왑체인의 다양한 link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkPresentModeKHR[표시 모드]에 따라 표시 엔진이 구현되는 방식이 결정됩니다.
 
 image::../../../chapters/images/wsi_engine.png[wsi_engine]
 
@@ -45,4 +45,4 @@ image::../../../chapters/images/wsi_engine.png[wsi_engine]
 
 모바일 기기는 회전이 가능하므로 애플리케이션 창의 논리적 방향과 디스플레이의 물리적 방향이 일치하지 않을 수 있습니다. 애플리케이션은 `세로모드(portrait)` 와 `가로모드(landscape)` 2가지 모드로 작동할 수 있어야 합니다. 이 두 모드의 차이는 해상도의 변화로 단순화할 수 있습니다. 그러나 일부 디스펠리에 하위 시스템은 항상 디스플레이 패널의 "`기본(native)`" (또는 "`물리적`") 방향에서 작동합니다. 장치가 회전되었으므로 원하는 효과를 얻으려면 애플리케이션 출력도 회전해야 합니다.
 
-안드로이드와 같은 모바일 플랫폼에서 애플리케이션이 Vulkan을 최대한 활용하려면 사전 회전을 구현하는 것이 필수입니다. 스왑체인 생성 시 방향을 지정하여 서페이스 회전을 처리하는 방법을 설명하는 link:https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html?m=1[Google의 자세한 블로그 게시물]이 있으며 link:https://github.com/google/vulkan-pre-rotation-demo[독립 실행형 예제]도 함께 제공됩니다. link:https://github.com/KhronosGroup/Vulkan-Samples[Vulkan-Samples]에는 사전 회전이 문제가 되는 이유에 대한 link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[훌륭한 글]과 쉐이더에서 이를 해결하는 방법을 보여주는 link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[실행 샘플]도 있습니다. Adreno GPU 기반 기기를 사용하는 경우, 퀄컴(Qualcomm)은 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_QCOM_render_pass_transform.html[VK_QCOM_render_pass_transform] 확장 기능을 사용하여 사전 회전을 구현할 것을 권장합니다.
+안드로이드와 같은 모바일 플랫폼에서 애플리케이션이 Vulkan을 최대한 활용하려면 사전 회전을 구현하는 것이 필수입니다. 스왑체인 생성 시 방향을 지정하여 서페이스 회전을 처리하는 방법을 설명하는 link:https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html?m=1[Google의 자세한 블로그 게시물]이 있으며 link:https://github.com/google/vulkan-pre-rotation-demo[독립 실행형 예제]도 함께 제공됩니다. link:https://github.com/KhronosGroup/Vulkan-Samples[Vulkan-Samples]에는 사전 회전이 문제가 되는 이유에 대한 link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[훌륭한 글]과 쉐이더에서 이를 해결하는 방법을 보여주는 link:https://github.com/KhronosGroup/Vulkan-Samples/tree/main/samples/performance/surface_rotation[실행 샘플]도 있습니다. Adreno GPU 기반 기기를 사용하는 경우, 퀄컴(Qualcomm)은 link:https://registry.khronos.org/vulkan/specs/latest/man/html/VK_QCOM_render_pass_transform.html[VK_QCOM_render_pass_transform] 확장 기능을 사용하여 사전 회전을 구현할 것을 권장합니다.


### PR DESCRIPTION
1.4 now has a `latest` path for the spec and updated all links to use it