### PR TITLE
Hide logos for docs site build, fix comment format

### DIFF
--- a/antora/modules/ROOT/pages/index.adoc
+++ b/antora/modules/ROOT/pages/index.adoc
@@ -1,8 +1,10 @@
-# Copyright 2022-2024 The Khronos Group Inc.
-# SPDX-License-Identifier: CC-BY-4.0
+// Copyright 2022-2024 The Khronos Group Inc.
+// SPDX-License-Identifier: CC-BY-4.0
 
+ifndef::site-gen-antora[]
 image::vulkan_logo.png[Vulkan Logo]
 image::khronos_logo.png[Khronos logo]
+endif::[]
 
 // Extracted from boilerplate at start of guide.adoc
 


### PR DESCRIPTION
With https://github.com/KhronosGroup/antora-ui-khronos/pull/11 we just merged dark mode for the docs site. This has issues with images that use black as a fixed color:

![image](https://github.com/user-attachments/assets/5d653237-c8db-40bf-a373-601a645a8d91)

As we don't display logos in the other components of the docs site, this PR simply hides the logos when building for the docs site.

It also fixes the comments being wrongly formatted, so they no longer show up as text on the page.

Would be great if we could merge this before Jon releases the next docs site update. Otherwise the guide landing page would look odd.