### PR TITLE
Cleanup Vulkan Spec chapter

### DIFF
--- a/chapters/vulkan_spec.adoc
+++ b/chapters/vulkan_spec.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2025 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 // Required for both single-page and combined guide xrefs to work
@@ -21,89 +21,38 @@ The Vulkan Spec can be built for any version and with any permutation of extensi
 
 When building the Vulkan Spec, you pass in what version of Vulkan to build for as well as what extensions to include. A Vulkan Spec without any extensions is also referred to as the link:https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions[core version] as it is the minimal amount of Vulkan an implementation needs to support in order to be xref:{chapters}vulkan_cts.adoc#vulkan-cts[conformant].
 
+== Vulkan Spec Version
+
+Vulkan 1.0 to 1.3, there was a dedicated version of the spec. To to reduce build permutation, starting with Vulkan 1.4 there is now a `latest` version that will always be updated to the latest version of Vulkan.
+
+The link:https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.html[Vulkan SDK] will always contain the version of the spec that it was created with.
+
 == Vulkan Spec Format
 
 The Vulkan Spec can be built into different formats.
 
-=== HTML Chunked
+=== Antora
 
-Due to the size of the Vulkan Spec, a chunked version is the default when you visit the default `index.html` page.
+To both combine various resources and improve navigation, there is now an link:https://docs.vulkan.org/spec/latest/index.html[Antora built version of the spec] that is recommanded to use.
 
-Example: link:https://registry.khronos.org/vulkan/specs/1.3/html/[https://registry.khronos.org/vulkan/specs/1.3/html/]
+=== HTML
 
-Prebuilt HTML Chunked Vulkan Spec
+If you want to view the Vulkan Spec in its entirety as HTML, you just need to view the `html/vkspec.html` file.
 
-  * The Vulkan SDK comes packaged with the chunked version of the spec. Each Vulkan SDK version includes the corresponding spec version. See the link:https://vulkan.lunarg.com/doc/sdk/latest/windows/chunked_spec/index.html[Chunked Specification] for the latest Vulkan SDK.
-  * Vulkan 1.0 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.0/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-wsi_extensions/html/[Core with WSI Extensions]
-  * Vulkan 1.1 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.1/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-khr-extensions/html/[Core with KHR Extensions]
-  * Vulkan 1.2 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.2/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-khr-extensions/html/[Core with KHR Extensions]
-  * Vulkan 1.3 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.3/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/[Core with KHR Extensions]
+https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html
 
-=== HTML Full
-
-If you want to view the Vulkan Spec in its entirety as HTML, you just need to view the `vkspec.html` file.
-
-Example: https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html
-
-Prebuilt HTML Full Vulkan Spec
-
-  * The Vulkan SDK comes packaged with Vulkan Spec in its entirety as HTML for the version corresponding to the Vulkan SDK version. See the link:https://vulkan.lunarg.com/doc/sdk/latest/windows/vkspec.html[HTML version of the Specification] for the latest Vulkan SDK. (Note: Slow to load. The advantage of the full HTML version is its searching capability).
-  * Vulkan 1.0 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.0/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-extensions/html/vkspec.html[Core with Extensions ]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-wsi_extensions/html/vkspec.html[Core with WSI Extensions]
-  * Vulkan 1.1 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.1/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-extensions/html/vkspec.html[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-khr-extensions/html/vkspec.html[Core with KHR Extensions]
-  * Vulkan 1.2 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-extensions/html/vkspec.html[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-khr-extensions/html/vkspec.html[Core with KHR Extensions]
-  * Vulkan 1.3 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/vkspec.html[Core with KHR Extensions]
+The Vulkan SDK comes packaged with Vulkan Spec in its entirety as HTML for the version corresponding to the Vulkan SDK version. (https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.html)
 
 === PDF
 
 To view the PDF format, visit the `pdf/vkspec.pdf` file.
 
-Example: https://registry.khronos.org/vulkan/specs/1.3/pdf/vkspec.pdf
+https://registry.khronos.org/vulkan/specs/latest/pdf/vkspec.pdf
 
-Prebuilt PDF Vulkan Spec
-
-  * Vulkan 1.0 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.0/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-extensions/pdf/vkspec.pdf[Core with Extensions ]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-wsi_extensions/pdf/vkspec.pdf[Core with WSI Extensions]
-  * Vulkan 1.1 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.1/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-extensions/pdf/vkspec.pdf[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-khr-extensions/pdf/vkspec.pdf[Core with KHR Extensions]
-  * Vulkan 1.2 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.2/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-extensions/pdf/vkspec.pdf[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-khr-extensions/pdf/vkspec.pdf[Core with KHR Extensions]
-  * Vulkan 1.3 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.3/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/pdf/vkspec.pdf[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/pdf/vkspec.pdf[Core with KHR Extensions]
+The Vulkan SDK also comes with a PDF version (https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.pdf)
 
 === Man pages
 
-The Khronos Group currently only host the Vulkan Man Pages for the latest version of the 1.3 spec, with all extensions, on the link:https://registry.khronos.org/vulkan/specs/latest/man/html/[online registry].
+The Khronos Group currently only host the Vulkan Man Pages for the latest version of the spec, with all extensions, on the link:https://registry.khronos.org/vulkan/specs/latest/man/html/[online registry].
 
 The Vulkan Man Pages can also be found in the VulkanSDK for each SDK version. See the link:https://vulkan.lunarg.com/doc/sdk/latest/windows/apispec.html[Man Pages] for the latest Vulkan SDK.

--- a/lang/jp/chapters/vulkan_spec.adoc
+++ b/lang/jp/chapters/vulkan_spec.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2025 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 // Required for both single-page and combined guide xrefs to work
@@ -20,89 +20,38 @@ Vulkan Spec は、どのバージョンでも、どのような拡張機能の�
 
 Vulkan Spec をビルドする際には、どのバージョン用か、どの拡張機能を含めるかを指定します。拡張機能を含まない Vulkan Spec はlink:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions[コアバージョン]とも呼ばれ、link:./../../../chapters/vulkan_cts.md[適合]するために実装がサポートするべき最小限の Vulkan となります。
 
+== Vulkan Spec バージョン
+
+Vulkan 1.0から1.3までは、スペックの専用バージョンがありました。ビルドの順列を減らすために、Vulkan 1.4から、常にVulkanの最新バージョンに更新される`latest`バージョンが存在するようになりました。
+
+リンク:https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.html[Vulkan SDK]は、常にそれが作成された仕様のバージョンを含んでいます。
+
 == Vulkan Spec フォーマット
 
 Vulkan Spec は、さまざまなフォーマットに対応しています。
 
-=== HTML チャンク
+=== Antora
 
-Vulkan Spec のサイズは大きいため、デフォルトの `index.html` ページにアクセスすると、チャンク版がデフォルトで表示されます。
+様々なリソースを統合し、ナビゲーションを改善するために、link:https://docs.vulkan.org/spec/latest/index.html[AntoraでビルドされたバージョンのSpec]の使用が推奨されています。
 
-例：link:https://www.khronos.org/registry/vulkan/specs/1.3/html/[https://www.khronos.org/registry/vulkan/specs/1.3/html/]
+=== HTML
 
-ビルド済み HTML チャンク Vulkan Spec
+Vulkan Spec 全体を HTML で見るには、`html/vkspec.html` ファイルを表示します。
 
-  * Vulkan SDK には、チャンク版の仕様書がパッケージされています。各バージョンの Vulkan SDK には、対応するバージョンの仕様書が含まれています。最新の Vulkan SDK については、link:https://vulkan.lunarg.com/doc/sdk/latest/windows/chunked_spec/index.html[Chunked Specification] をご覧ください。 
-  * Vulkan 1.0 Specification
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0/html/[コア]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/[コアと拡張機能]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0-wsi_extensions/html/[コアと WSI 拡張機能]
-  * Vulkan 1.1 Specification
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1/html/[コア]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/[コアと拡張機能]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1-khr-extensions/html/[コアと KHR 拡張機能]
-  * Vulkan 1.2 Specification
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2/html/[コア]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/[コアと拡張機能]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/[コアと KHR 拡張機能]
-  * Vulkan 1.3 Specification
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3/html/[コア]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/[コアと拡張機能]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-khr-extensions/html/[コアと KHR 拡張機能]
+https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html
 
-=== HTML フル
-
-Vulkan Spec 全体を HTML で見るには、`vkspec.html` ファイルを表示します。
-
-例： https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html
-
-ビルド済み HTML フル Vulkan Spec 
-
-  * Vulkan SDK には、対応したバージョンの Vulkan Spec が HTML として丸ごとパッケージされています。最新の Vulkan SDK に対応するバージョンの link:https://vulkan.lunarg.com/doc/sdk/latest/windows/vkspec.html[HTML 版の Specification] をご覧ください。（注意：読み込みに時間がかかります。フル HTML 版の利点は検索機能です。） 
-  * Vulkan 1.0 Specification 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html[コア] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html[コアと拡張機能] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0-wsi_extensions/html/vkspec.html[コアと WSI 拡張機能] 
-  * Vulkan 1.1 Specification 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1/html/vkspec.html[コア] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html[コアと拡張機能] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1-khr-extensions/html/vkspec.html[コアと KHR 拡張機能] 
-  * Vulkan 1.2 Specification 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2/html/vkspec.html[コア] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html[コアと拡張機能] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/vkspec.html[コアと KHR 拡張機能]
-  * Vulkan 1.3 Specification
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html[コア]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html[コアと拡張機能]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-khr-extensions/html/vkspec.html[コアと KHR 拡張機能]
+Vulkan SDK には、対応したバージョンの Vulkan Spec が HTML として丸ごとパッケージされています。最新の Vulkan SDK に対応するバージョンの link:https://vulkan.lunarg.com/doc/sdk/latest/windows/vkspec.html[HTML 版の Specification] をご覧ください。
 
 === PDF
 
 PDF フォーマットは `pdf/vkspec.pdf` ファイルをご覧ください。
 
-例： https://www.khronos.org/registry/vulkan/specs/1.3/pdf/vkspec.pdf
+https://registry.khronos.org/vulkan/specs/latest/pdf/vkspec.pdf
 
-ビルド済み PDF Vulkan Spec 
-
-  * Vulkan 1.0 Specification 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0/pdf/vkspec.pdf[コア] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0-extensions/pdf/vkspec.pdf[コアと拡張機能] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.0-wsi_extensions/pdf/vkspec.pdf[コアと WSI 拡張機能] 
-  * Vulkan 1.1 Specification 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1/pdf/vkspec.pdf[コア] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1-extensions/pdf/vkspec.pdf[コアと拡張機能] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.1-khr-extensions/pdf/vkspec.pdf[コアと KHR 拡張機能] 
-  * Vulkan 1.2 Specification 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2/pdf/vkspec.pdf[コア] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2-extensions/pdf/vkspec.pdf[コアと拡張機能] 
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.2-khr-extensions/pdf/vkspec.pdf[コアと KHR 拡張機能]
-  * Vulkan 1.3 Specification
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3/pdf/vkspec.pdf[コア]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/pdf/vkspec.pdf[コアと拡張機能]
-  ** link:https://www.khronos.org/registry/vulkan/specs/1.3-khr-extensions/pdf/vkspec.pdf[コアと KHR 拡張機能]
+Vulkan SDKにもPDF版が付属しています（https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.pdf）。
 
 === マニュアルページ
 
-Khronos Group は現在、最新バージョンの1.3仕様のすべての拡張機能を含む Vulkan Man Pages のみを link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/[オンラインレジストリ]でホストしています。
+Khronos Group は現在、最新バージョンの仕様のすべての拡張機能を含む Vulkan Man Pages のみを link:https://registry.khronos.org/vulkan/specs/latest/man/html/[オンラインレジストリ]でホストしています。
 
 また、Vulkan Man Pages は、各バージョンの Vulkan SDK にも掲載されています。最新の Vulkan SDK の link:https://vulkan.lunarg.com/doc/sdk/latest/windows/apispec.html[マニュアルページ] をご覧ください。

--- a/lang/kor/chapters/vulkan_spec.adoc
+++ b/lang/kor/chapters/vulkan_spec.adoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Khronos Group, Inc.
+// Copyright 2019-2025 The Khronos Group, Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 // Required for both single-page and combined guide xrefs to work
@@ -21,89 +21,40 @@ Vulkan Spec은 모든 버전과 모든 확장 기능 조합을 사용하여 빌�
 
 Vulkan Spec을 빌드할 때, 어떤 버전용인지, 어떤 확장 기능을 포함할지 지정합니다. 확장 기능이 없는 Vulkan Spen을 link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#extendingvulkan-coreversions[core version]이라고도 하는데, 이는 구현이 xref:{chapters}vulkan_cts.adoc#vulkan-cts[호환]되기 위해 지원해야 하는 최소한의 Vulkan이 됩니다.
 
+== Vulkan Spec 버전
+
+Vulkan 1.0에서 1.3까지는 전용 버전의 Spec이 있었습니다. 빌드 순열을 줄이기 위해 Vulkan 1.4부터는 항상 최신 버전의 Vulkan으로 업데이트되는 '최신' 버전이 있습니다.
+
+링크: https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.html[Vulkan SDK]에는 항상 생성된 Spec 버전이 포함됩니다.
+
 == Vulkan Spec 포맷
 
 Vulkan Spec은 다양한 포맷으로 빌드할 수 있습니다.
 
-=== HTML 청크(Chunked)
+=== Antora
 
-Vulkan Spec의 크기로 인해 기본 `index.html` 페이지를 방문하면 청크 버전이 기본값으로 표시됩니다.
+다양한 리소스를 결합하고 탐색을 개선하기 위해 이제 링크:https://docs.vulkan.org/spec/latest/index.html[Antora 빌드 Spec 버전]을 사용할 것을 권장합니다.
 
-예시: link:https://registry.khronos.org/vulkan/specs/1.3/html/[https://registry.khronos.org/vulkan/specs/1.3/html/]
+=== HTML
 
-사전 빌드된 HTML 청크 Vulkan Spec
+Vulkan Spec 전체를 HTML로 보려면 `html/vkspec.html` 파일을 보기만 하면 됩니다.
 
-  * Vulkan SDK는 청크 버전의 사양과 함께 패키지로 제공됩니다. 각 Vulkan SDK 버전에는 해당 사양 버전이 포함되어 있습니다.최신 Vulkan SDK는 link:https://vulkan.lunarg.com/doc/sdk/latest/windows/chunked_spec/index.html[Chunked Specification]를 참조하세요.
-  * Vulkan 1.0 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.0/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-wsi_extensions/html/[Core with WSI Extensions]
-  * Vulkan 1.1 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.1/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-khr-extensions/html/[Core with KHR Extensions]
-  * Vulkan 1.2 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.2/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-khr-extensions/html/[Core with KHR Extensions]
-  * Vulkan 1.3 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.3/html/[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/[Core with KHR Extensions]
+https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html
 
-=== HTML Full
+벌칸 SDK는 해당 버전에 해당하는 벌칸 스펙 전체가 HTML로 패키징되어 제공됩니다. (https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.html)
 
-Vulkan Spec 전체를 HTML로 보려면 `vkspec.html` 파일을 보기만 하면 됩니다.
-
-예시: https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html
-
-사전 빌드된 HTML Full Vulkan Spec
-
-  * Vulkan SDK는 Vulkan Spec 전체가 Vulkan SDK 버전에 해당하는 버전의 HTML로 패키징되어 제공됩니다. 최신 Vulkan SDK는 link:https://vulkan.lunarg.com/doc/sdk/latest/windows/vkspec.html[HTML 버전의 사양서]를 참조하세요(참고: 로딩 속도가 느립니다. 전체 HTML 버전의 장점은 검색 기능입니다).
-  * Vulkan 1.0 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.0/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-extensions/html/vkspec.html[Core with Extensions ]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-wsi_extensions/html/vkspec.html[Core with WSI Extensions]
-  * Vulkan 1.1 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.1/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-extensions/html/vkspec.html[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-khr-extensions/html/vkspec.html[Core with KHR Extensions]
-  * Vulkan 1.2 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-extensions/html/vkspec.html[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-khr-extensions/html/vkspec.html[Core with KHR Extensions]
-  * Vulkan 1.3 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/vkspec.html[Core with KHR Extensions]
+Vulkan SDK는 Vulkan Spec 전체가 Vulkan SDK 버전에 해당하는 버전의 HTML로 패키징되어 제공됩니다. 최신 Vulkan SDK는 (https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.html)
 
 === PDF
 
 PDF 포맷은 `pdf/vkspec.pdf` 파일을 보세요.
 
-예시: https://registry.khronos.org/vulkan/specs/1.3/pdf/vkspec.pdf
+https://registry.khronos.org/vulkan/specs/latest/pdf/vkspec.pdf
 
-사전 빌드된 PDF Vulkan Spec
-
-  * Vulkan 1.0 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.0/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-extensions/pdf/vkspec.pdf[Core with Extensions ]
-  ** link:https://registry.khronos.org/vulkan/specs/1.0-wsi_extensions/pdf/vkspec.pdf[Core with WSI Extensions]
-  * Vulkan 1.1 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.1/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-extensions/pdf/vkspec.pdf[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.1-khr-extensions/pdf/vkspec.pdf[Core with KHR Extensions]
-  * Vulkan 1.2 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.2/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-extensions/pdf/vkspec.pdf[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.2-khr-extensions/pdf/vkspec.pdf[Core with KHR Extensions]
-  * Vulkan 1.3 Specification
-  ** link:https://registry.khronos.org/vulkan/specs/1.3/pdf/vkspec.pdf[Core]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-extensions/pdf/vkspec.pdf[Core with Extensions]
-  ** link:https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/pdf/vkspec.pdf[Core with KHR Extensions]
+Vulkan SDK는 PDF 버전도 함께 제공됩니다(https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.pdf).
 
 === Man pages
 
-크로노스 그룹은 현재 link:https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/[온라인 레지스트리]에서 모든 확장 기능을 포함한 최신 버전의 1.3 사양에 대한 Vulkan Man Pages만 호스팅 하고 있습니다.
+크로노스 그룹은 현재 link:https://registry.khronos.org/vulkan/specs/latest/man/html/[온라인 레지스트리]에서 모든 확장 기능을 포함한 최신 버전의 사양에 대한 Vulkan Man Pages만 호스팅 하고 있습니다.
 
 Vulkan Man Pages는 각 SDK 버전에 대한 Vulkan SDK에서도 확인할 수 있습니다. 최신 Vulkan SDK는 link:https://vulkan.lunarg.com/doc/sdk/latest/windows/apispec.html[Man Pages]를 참조하세요.


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-Guide/issues/287

With both the new antora site and using `latest`, this chapter needed a cleanup with the goal to keep things simpler (I felt we now can remove a lot of legacy knowledge and aim people towards the new modern flows we have) 