### PR TITLE
Add link to find Dynamic State Map

### DIFF
--- a/chapters/dynamic_state.adoc
+++ b/chapters/dynamic_state.adoc
@@ -9,7 +9,7 @@ ifndef::images[:images: images/]
 
 [NOTE]
 ====
-link:https://docs.vulkan.org/spec/latest/chapters/pipelines.html#pipelines-dynamic-state[Vulkan Spec chapter]
+xref:{chapters}dynamic_state_map.adoc[List of all dynamic states with details]
 ====
 
 == Overview

--- a/lang/jp/chapters/dynamic_state.adoc
+++ b/lang/jp/chapters/dynamic_state.adoc
@@ -8,7 +8,7 @@ ifndef::chapters[:chapters:]
 
 [NOTE]
 ====
-link:https://docs.vulkan.org/spec/latest/chapters/pipelines.html#pipelines-dynamic-state[Vulkan Spec の章]
+xref:{chapters}dynamic_state_map.adoc[すべての動的状態のリストと詳細]
 ====
 
 == 概要

--- a/lang/kor/chapters/dynamic_state.adoc
+++ b/lang/kor/chapters/dynamic_state.adoc
@@ -9,7 +9,7 @@ ifndef::images[:images: images/]
 
 [NOTE]
 ====
-link:https://docs.vulkan.org/spec/latest/chapters/pipelines.html#pipelines-dynamic-state[Vulkan Spec chapter]
+xref:{chapters}dynamic_state_map.adoc[세부 정보가 포함된 모든 동적 상태 목록]
 ====
 
 == Overview


### PR DESCRIPTION
https://docs.vulkan.org/guide/latest/dynamic_state.html doesn't point to https://docs.vulkan.org/guide/latest/dynamic_state_map.html as pointed out in https://github.com/KhronosGroup/Vulkan-Docs/issues/2504#issuecomment-2718671498