### PR TITLE
Compiler Explorer example for VK_KHR_storage_buffer_storage_class

### DIFF
--- a/chapters/extensions/shader_features.adoc
+++ b/chapters/extensions/shader_features.adoc
@@ -123,21 +123,24 @@ If you target Vulkan 1.0 (which requires SPIR-V 1.0), using glslang `--target-en
 
 [source,swift]
 ----
-    Decorate 7(ssbo) BufferBlock
-8:  TypePointer Uniform 7(ssbo)
-9:  8(ptr) Variable Uniform
-12: TypePointer Uniform 6(int)
+       OpDecorate %ssbo BufferBlock
+%ptr = OpTypePointer Uniform %ssbo
+%var = OpVariable %ptr Uniform
 ----
 
 Since `SPV_KHR_storage_buffer_storage_class` was added to SPIR-V 1.3, if you target Vulkan 1.1 (which requires SPIR-V 1.3) ,using glslang `--target-env vulkan1.1`, it will make use of the new `StorageBuffer` class.
 
 [source,swift]
 ----
-    Decorate 7(ssbo) Block
-8:  TypePointer StorageBuffer 7(ssbo)
-9:  8(ptr) Variable StorageBuffer
-12: TypePointer StorageBuffer 6(int)
+       OpDecorate %ssbo Block
+%ptr = OpTypePointer StorageBuffer %ssbo
+%var = OpVariable %ptr StorageBuffer
 ----
+
+[NOTE]
+====
+link:https://godbolt.org/z/a8WMEeejs[Try Online]
+====
 
 [[VK_KHR_variable_pointers]]
 == VK_KHR_variable_pointers

--- a/lang/jp/chapters/extensions/shader_features.adoc
+++ b/lang/jp/chapters/extensions/shader_features.adoc
@@ -123,21 +123,24 @@ Vulkan 1.0（SPIR-V 1.0が必要）をターゲットにして、glslang の `--
 
 [source,swift]
 ----
-    Decorate 7(ssbo) BufferBlock
-8:  TypePointer Uniform 7(ssbo)
-9:  8(ptr) Variable Uniform
-12: TypePointer Uniform 6(int)
+       OpDecorate %ssbo BufferBlock
+%ptr = OpTypePointer Uniform %ssbo
+%var = OpVariable %ptr Uniform
 ----
 
 SPIR-V 1.3 には `SPV_KHR_storage_buffer_storage_class` が追加されたので、Vulkan 1.1 (SPIR-V 1.3 が必要) をターゲットにして、glslang の `--target-env vulkan1.1` を使用すると、新しい `StorageBuffer` クラスが使用されます。
 
 [source,swift]
 ----
-    Decorate 7(ssbo) Block
-8:  TypePointer StorageBuffer 7(ssbo)
-9:  8(ptr) Variable StorageBuffer
-12: TypePointer StorageBuffer 6(int)
+       OpDecorate %ssbo Block
+%ptr = OpTypePointer StorageBuffer %ssbo
+%var = OpVariable %ptr StorageBuffer
 ----
+
+[NOTE]
+====
+link:https://godbolt.org/z/a8WMEeejs[オンラインで試す]
+====
 
 [[VK_KHR_variable_pointers]]
 == VK_KHR_variable_pointers

--- a/lang/kor/chapters/extensions/shader_features.adoc
+++ b/lang/kor/chapters/extensions/shader_features.adoc
@@ -123,21 +123,24 @@ Vulkan 1.0 (SPIR-V 1.0이 필요)을 대상으로 하는 경우, glslang `--targ
 
 [source,swift]
 ----
-    Decorate 7(ssbo) BufferBlock
-8:  TypePointer Uniform 7(ssbo)
-9:  8(ptr) Variable Uniform
-12: TypePointer Uniform 6(int)
+       OpDecorate %ssbo BufferBlock
+%ptr = OpTypePointer Uniform %ssbo
+%var = OpVariable %ptr Uniform
 ----
 
 SPIR-V 1.3에 `SPV_KHR_storage_buffer_storage_class` 가 추가되었으므로, (SPIR-V 1.3이 필요) Vulkan 1.1을 타깃으로 하는 경우, glslang `--target-env vulkan1.1` 을 사용하면 새로운 `StorageBuffer` 클래스를 사용합니다.
 
 [source,swift]
 ----
-    Decorate 7(ssbo) Block
-8:  TypePointer StorageBuffer 7(ssbo)
-9:  8(ptr) Variable StorageBuffer
-12: TypePointer StorageBuffer 6(int)
+       OpDecorate %ssbo Block
+%ptr = OpTypePointer StorageBuffer %ssbo
+%var = OpVariable %ptr StorageBuffer
 ----
+
+[NOTE]
+====
+link:https://godbolt.org/z/a8WMEeejs[온라인 체험]
+====
 
 [[VK_KHR_variable_pointers]]
 == VK_KHR_variable_pointers


### PR DESCRIPTION
has to show yet-another-person what `VK_KHR_storage_buffer_storage_class` was and why using glslang with `--target-env vulkan1.0` is bad, so decided to put the compiler explorer example here