### PR TITLE
Fix Features documentation to include sTypes

### DIFF
--- a/chapters/enabling_features.adoc
+++ b/chapters/enabling_features.adoc
@@ -51,8 +51,10 @@ For **all features**, including the Core 1.0 Features, use `VkPhysicalDeviceFeat
 [source,cpp]
 ----
 VkPhysicalDeviceShaderDrawParametersFeatures ext_feature = {};
+ext_feature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
 
 VkPhysicalDeviceFeatures2 physical_features2 = {};
+physical_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 physical_features2.pNext = &ext_feature;
 
 vkGetPhysicalDeviceFeatures2(physical_device, &physical_features2);
@@ -70,8 +72,10 @@ The same works for the "`Future Core Version Features`" too.
 [source,cpp]
 ----
 VkPhysicalDeviceVulkan11Features features11 = {};
+features11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
 
 VkPhysicalDeviceFeatures2 physical_features2 = {};
+physical_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 physical_features2.pNext = &features11;
 
 vkGetPhysicalDeviceFeatures2(physical_device, &physical_features2);


### PR DESCRIPTION
The current version of the [Enabling Features](https://docs.vulkan.org/guide/latest/enabling_features.html) page includes a couple examples about how to query feature support for extension or future Vulkan versions.

These examples do not include the important step of setting the `sType` field for each feature struct. This may have been omitted for brevity, but I feel like it's important to make sure the person who reads this knows that setting the `sType` fields is important, as otherwise the code simply doesn't work.