### PR TITLE
Fix use of backquotes with word characters on either side.

### DIFF
--- a/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
+++ b/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
@@ -12,7 +12,7 @@ ifndef::images[:images: ../images/]
 Promoted to core in Vulkan 1.2
 ====
 
-When creating a `VkFramebuffer` you normally need to pass the ``VkImageView`s`` being used in `VkFramebufferCreateInfo::pAttachments`. Needing the `VkImageView` forces an application to make a framebuffer for each swapchain image. With `VK_KHR_imageless_framebuffer` the `VkImageView` information is given at `vkCmdBeginRenderPass` time instead. This means only one `VkFramebuffer` for all the swapchain images. It is important to notice that when the size of the swapchain changes, the `VkFramebuffer` will still need to be recreated to adjust information such as the `height` and `width`.
+When creating a `VkFramebuffer` you normally need to pass the ``VkImageView``s being used in `VkFramebufferCreateInfo::pAttachments`. Needing the `VkImageView` forces an application to make a framebuffer for each swapchain image. With `VK_KHR_imageless_framebuffer` the `VkImageView` information is given at `vkCmdBeginRenderPass` time instead. This means only one `VkFramebuffer` for all the swapchain images. It is important to notice that when the size of the swapchain changes, the `VkFramebuffer` will still need to be recreated to adjust information such as the `height` and `width`.
 
 To use an imageless `VkFramebuffer`
 

--- a/lang/kor/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
+++ b/lang/kor/chapters/extensions/VK_KHR_imageless_framebuffer.adoc
@@ -12,7 +12,7 @@ ifndef::images[:images: ../images/]
 Vulkan 1.2에서 코어로 승격됨
 ====
 
-`VkFramebuffer` 를 생성할 때 일반적으로 `VkFramebufferCreateInfo::pAttachments` 에서 사용 중인 `VkImageView`s`` 를 전달해야 합니다. `VkImageView` 가 필요하면 애플리케이션이 각 스왑체인 이미지에 대한 프레임버퍼를 만들어야 합니다. `VK_KHR_imageless_framebuffer` 를 사용하면 `vkCmdBeginRenderPass` 시점에 `VkImageView` 정보가 대신 제공됩니다. 이는 모든 스왑체인 이미지에 대해 `VkFramebuffer` 하나만 필요하다는 것을 의미합니다. 주의할 점은 스왑체인의 크기가 변경되더라도 `VkFramebuffer`는 `높이(height)`와 `폭(width)`과 같은 정보를 조정하기 위해 다시 생성되어야 한다는 것입니다.
+`VkFramebuffer` 를 생성할 때 일반적으로 `VkFramebufferCreateInfo::pAttachments` 에서 사용 중인 ``VkImageView``s 를 전달해야 합니다. `VkImageView` 가 필요하면 애플리케이션이 각 스왑체인 이미지에 대한 프레임버퍼를 만들어야 합니다. `VK_KHR_imageless_framebuffer` 를 사용하면 `vkCmdBeginRenderPass` 시점에 `VkImageView` 정보가 대신 제공됩니다. 이는 모든 스왑체인 이미지에 대해 `VkFramebuffer` 하나만 필요하다는 것을 의미합니다. 주의할 점은 스왑체인의 크기가 변경되더라도 `VkFramebuffer`는 `높이(height)`와 `폭(width)`과 같은 정보를 조정하기 위해 다시 생성되어야 한다는 것입니다.
 
 이미지 없는 `VkFramebuffer` 를 이용하려면
 


### PR DESCRIPTION
Fixes #212

Note that this renders as (tt font) VkImage closely followed by (regular font) s, which is fine, but it might be more clear to write something like "the VkImage objects/handles".