### PR TITLE
Fix typo: duplicated "to" in vulkan_spec.adoc

### DIFF
--- a/chapters/vulkan_spec.adoc
+++ b/chapters/vulkan_spec.adoc
@@ -23,7 +23,7 @@ When building the Vulkan Spec, you pass in what version of Vulkan to build for a
 
 == Vulkan Spec Version
 
-Vulkan 1.0 to 1.3, there was a dedicated version of the spec. To to reduce build permutation, starting with Vulkan 1.4 there is now a `latest` version that will always be updated to the latest version of Vulkan.
+Vulkan 1.0 to 1.3, there was a dedicated version of the spec. To reduce build permutation, starting with Vulkan 1.4 there is now a `latest` version that will always be updated to the latest version of Vulkan.
 
 The link:https://vulkan.lunarg.com/doc/sdk/1.4.304.0/windows/1.4-extensions/vkspec.html[Vulkan SDK] will always contain the version of the spec that it was created with.
 


### PR DESCRIPTION
Fixed a minor typo in the "Vulkan Spec Version" section where the word "to" was duplicated.