### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -51,6 +51,9 @@ jobs:
             sources:
             - url: .
               start_path: antora
+          asciidoc:
+            attributes:
+              project-local-ci: ''
           ui:
             bundle:
               url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,7 +8,7 @@ path = [
     "chapters/**.md",
     "chapters/**.png",
     "chapters/**.svg",
-    "chapters/slang-write-once-run-anywhere-graphic.webp",
+    "chapters/images/slang-write-once-run-anywhere-graphic.webp",
 ]
 SPDX-FileCopyrightText = "2026 The Khronos Group, Inc."
 SPDX-License-Identifier = "CC-BY-4.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,6 +8,7 @@ path = [
     "chapters/**.md",
     "chapters/**.png",
     "chapters/**.svg",
+    "chapters/slang-write-once-run-anywhere-graphic.webp",
 ]
 SPDX-FileCopyrightText = "2026 The Khronos Group, Inc."
 SPDX-License-Identifier = "CC-BY-4.0"

--- a/chapters/slang.adoc
+++ b/chapters/slang.adoc
@@ -29,7 +29,9 @@ If you are new to Slang, here are some educational points:
 * link:https://shader-slang.org/docs/coming-from-hlsl/[Porting from HLSL]
 * link:https://shader-slang.org/docs/coming-from-glsl/[Porting from GLSL]
 * link:https://shader-slang.org/slang-playground/[Interactive Slang shader playground]
+ifndef::project-local-ci[]
 * xref:samples::README.adoc[The Vulkan Samples come with Slang shaders]
+endif::[]
 
 == Key differences between Slang and GLSL
 


### PR DESCRIPTION
This PR fixes two failing CI steps:

* REUSE CI is fixed by specifying that a new image added for the Slang landing page is properly attributed
* Antora build CI is fixed by setting and using a define for CI only that excludes a link to the samples component for CI only
